### PR TITLE
Add `datasets` module

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,6 +8,7 @@ max-line-length = 79
 max-complexity = 18
 per-file-ignores =
     */__init__.py: F401
+   mosaic/datasets.py: E501
 exclude =
     .git,
     docs,

--- a/dev-environment.txt
+++ b/dev-environment.txt
@@ -8,6 +8,7 @@ numpy
 pooch
 pyproj
 scipy
+tqdm
 xarray
 
 # Building

--- a/dev-environment.txt
+++ b/dev-environment.txt
@@ -5,6 +5,7 @@ h5netcdf
 netcdf4
 matplotlib-base
 numpy
+pooch
 pyproj
 scipy
 xarray

--- a/docs/developers_guide/api.md
+++ b/docs/developers_guide/api.md
@@ -10,6 +10,7 @@
 
     polypcolor
     Descriptor
+    datasets.open_dataset
 ```
 
 

--- a/mosaic/__init__.py
+++ b/mosaic/__init__.py
@@ -1,7 +1,9 @@
+from mosaic import datasets
 from mosaic.descriptor import Descriptor
 from mosaic.polypcolor import polypcolor
 
 __all__ = [
+    "datasets",
     "polypcolor",
     "Descriptor"
 ]

--- a/mosaic/datasets.py
+++ b/mosaic/datasets.py
@@ -14,6 +14,11 @@ registry = {
             "sha256_hash": "sha256:524d2d5a93851395a3bdfafb30a5acb2a3dbbecd0db07cd29e5e3f87da6eb82f"
             },
 
+        "QU.240km": {
+            "lcrc_path": "inputdata/ocn/mpas-o/oQU240/ocean.QU.240km.151209.nc",
+            "sha256_hash": "sha256:a3758f88ceff3d91e86dba7922f6dd7d5672157b4793ef78214624ab8b2724ae"
+            },
+
         "mpaso.EC30to60E2r3": {
             "lcrc_path": "inputdata/ocn/mpas-o/EC30to60E2r3/mpaso.EC30to60E2r3.230313.nc",
             "sha256_hash": "sha256:55e7cc33c890f7b9f1188bcc07fd8218b57cb1cd5ba32ee66fe3162a36995a7c"
@@ -42,7 +47,7 @@ mesh_db = pooch.create(
 def open_dataset(
     name: str,
     cache: bool = True,
-    **kws,
+    **kwargs,
 ) -> Dataset:
     """
     Open a dataset from the lcrc database (requires internet), unless a local 
@@ -50,18 +55,18 @@ def open_dataset(
     
     Available datasets:
 
-    * ``"QU.960km"`` : ...
-    * ``"mpaso.EC30to60E2r3"`` : ...
-    * ``"mpasli.AIS8to30"`` : ...
+    * ``"QU.960km"`` : Quasi-uniform spherical mesh, with approximately 960km horizontal resolution
+    * ``"QU.240km"`` : Quasi-uniform spherical mesh, with approximately 240km horizontal resolution
+    * ``"mpaso.EC30to60E2r3"`` : (E)ddy-(C)losure 30 to 60 km MPAS-Ocean mesh
+    * ``"mpasli.AIS8to30"`` : 8-30 km resolution planar non-periodic MALI mesh of Antarctica
 
     Parameters
     ----------
     name : str
-        Name of the file containing the dataset.
-        e.g. 'air_temperature'
+        Name of the file containing the dataset. (e.g. ``"QU.960km"``)
     cache : bool, optional
         If True, then cache data locally for use on subsequent calls
-    **kws : dict, optional
+    kwargs : dict, optional
         Passed to xarray.open_dataset
     """
 
@@ -72,10 +77,10 @@ def open_dataset(
     # use human readable registry to find filepath on lcrc
     lcrc_path = registry[name]["lcrc_path"]
     # retrive the file using pooch
-    filepath = mesh_db.fetch(lcrc_path)
+    filepath = mesh_db.fetch(lcrc_path, progressbar=True)
     
-    # open dataset
-    ds = xr.open_dataset(filepath, **kws)
+    # open dataset, and squeeze time dimensions if present
+    ds = xr.open_dataset(filepath, **kwargs).squeeze()
 
     # if `cache==False` persist file in memory and delete the downloaded file
     if not cache: 

--- a/mosaic/datasets.py
+++ b/mosaic/datasets.py
@@ -1,47 +1,48 @@
-import os
 import pathlib
+
 import pooch
 import xarray as xr
-
-from mosaic.version import __version__
 from xarray import Dataset
 
-# this dictionary uses the short handed mesh names for convience, 
+from mosaic.version import __version__
+
+# this dictionary uses the short handed mesh names for convience,
 # but can not be parsed by pooch
 registry = {
-        "QU.960km": {
-            "lcrc_path": "mpas_standalonedata/mpas-ocean/mesh_database/mesh.QU.960km.151026.nc", 
-            "sha256_hash": "sha256:524d2d5a93851395a3bdfafb30a5acb2a3dbbecd0db07cd29e5e3f87da6eb82f"
-            },
+    "QU.960km": {
+        "lcrc_path": "mpas_standalonedata/mpas-ocean/mesh_database/mesh.QU.960km.151026.nc",
+        "sha256_hash": "sha256:524d2d5a93851395a3bdfafb30a5acb2a3dbbecd0db07cd29e5e3f87da6eb82f"
+    },
 
-        "QU.240km": {
-            "lcrc_path": "inputdata/ocn/mpas-o/oQU240/ocean.QU.240km.151209.nc",
-            "sha256_hash": "sha256:a3758f88ceff3d91e86dba7922f6dd7d5672157b4793ef78214624ab8b2724ae"
-            },
+    "QU.240km": {
+        "lcrc_path": "inputdata/ocn/mpas-o/oQU240/ocean.QU.240km.151209.nc",
+        "sha256_hash": "sha256:a3758f88ceff3d91e86dba7922f6dd7d5672157b4793ef78214624ab8b2724ae"
+    },
 
-        "mpaso.EC30to60E2r3": {
-            "lcrc_path": "inputdata/ocn/mpas-o/EC30to60E2r3/mpaso.EC30to60E2r3.230313.nc",
-            "sha256_hash": "sha256:55e7cc33c890f7b9f1188bcc07fd8218b57cb1cd5ba32ee66fe3162a36995a7c"
-            },
+    "mpaso.EC30to60E2r3": {
+        "lcrc_path": "inputdata/ocn/mpas-o/EC30to60E2r3/mpaso.EC30to60E2r3.230313.nc",
+        "sha256_hash": "sha256:55e7cc33c890f7b9f1188bcc07fd8218b57cb1cd5ba32ee66fe3162a36995a7c"
+    },
 
-        "mpasli.AIS8to30": {
-            "lcrc_path": "inputdata/glc/mpasli/mpas.ais8to30km/ais_8to30km.20221027.nc", 
-            "sha256_hash": "sha256:932a1989ff8e51223413ef3ff0056d6737a1fc7f53e440359884a567a93413d2"
-            }
-        }
+    "mpasli.AIS8to30": {
+        "lcrc_path": "inputdata/glc/mpasli/mpas.ais8to30km/ais_8to30km.20221027.nc",
+        "sha256_hash": "sha256:932a1989ff8e51223413ef3ff0056d6737a1fc7f53e440359884a567a93413d2"
+    }
+}
 
-# create a parsable registry for pooch from human friendly one 
-_registry = {registry[m]["lcrc_path"] : registry[m]["sha256_hash"] for m in registry} 
+# create a parsable registry for pooch from human friendly one
+_registry = {registry[m]["lcrc_path"]: registry[m]["sha256_hash"] for m in registry}
 
 mesh_db = pooch.create(
     # Use the default cache folder for the operating system
     path=pooch.os_cache("mosaic"),
     # The remote data is from LCRC
     base_url="https://web.lcrc.anl.gov/public/e3sm",
-    version=__version__, 
+    version=__version__,
     # If this is a development version, get the data from the "main" branch
     version_dev="main",
     registry=_registry)
+
 
 # idea borrowed/copied from xarray
 def open_dataset(
@@ -50,9 +51,9 @@ def open_dataset(
     **kwargs,
 ) -> Dataset:
     """
-    Open a dataset from the lcrc database (requires internet), unless a local 
-    copy is found. 
-    
+    Open a dataset from the lcrc database (requires internet), unless a local
+    copy is found.
+
     Available datasets:
 
     * ``"QU.960km"`` : Quasi-uniform spherical mesh, with approximately 960km horizontal resolution
@@ -73,17 +74,17 @@ def open_dataset(
     # invalid dataset name requested
     if name not in registry:
         raise FileNotFoundError(f"Requsted dataset \"{name}\" cannot be found")
-    
+
     # use human readable registry to find filepath on lcrc
     lcrc_path = registry[name]["lcrc_path"]
     # retrive the file using pooch
     filepath = mesh_db.fetch(lcrc_path, progressbar=True)
-    
+
     # open dataset, and squeeze time dimensions if present
     ds = xr.open_dataset(filepath, **kwargs).squeeze()
 
     # if `cache==False` persist file in memory and delete the downloaded file
-    if not cache: 
+    if not cache:
         ds = ds.load()
         pathlib.Path(filepath).unlink()
 

--- a/mosaic/datasets.py
+++ b/mosaic/datasets.py
@@ -85,7 +85,7 @@ def open_dataset(
     if cache_dir:
         # join the url paths together for the requested file
         url = os.path.join(mesh_db.base_url, lcrc_path)
-        # get the known has of the file
+        # get the known hash of the file
         known_hash = registry[name]["sha256_hash"]
         # retrive the file using pooch, and cache in custom location
         filepath = pooch.retrieve(

--- a/mosaic/datasets.py
+++ b/mosaic/datasets.py
@@ -1,0 +1,85 @@
+import os
+import pathlib
+import pooch
+import xarray as xr
+
+from mosaic.version import __version__
+from xarray import Dataset
+
+# this dictionary uses the short handed mesh names for convience, 
+# but can not be parsed by pooch
+registry = {
+        "QU.960km": {
+            "lcrc_path": "mpas_standalonedata/mpas-ocean/mesh_database/mesh.QU.960km.151026.nc", 
+            "sha256_hash": "sha256:524d2d5a93851395a3bdfafb30a5acb2a3dbbecd0db07cd29e5e3f87da6eb82f"
+            },
+
+        "mpaso.EC30to60E2r3": {
+            "lcrc_path": "inputdata/ocn/mpas-o/EC30to60E2r3/mpaso.EC30to60E2r3.230313.nc",
+            "sha256_hash": "sha256:55e7cc33c890f7b9f1188bcc07fd8218b57cb1cd5ba32ee66fe3162a36995a7c"
+            },
+
+        "mpasli.AIS8to30": {
+            "lcrc_path": "inputdata/glc/mpasli/mpas.ais8to30km/ais_8to30km.20221027.nc", 
+            "sha256_hash": "sha256:932a1989ff8e51223413ef3ff0056d6737a1fc7f53e440359884a567a93413d2"
+            }
+        }
+
+# create a parsable registry for pooch from human friendly one 
+_registry = {registry[m]["lcrc_path"] : registry[m]["sha256_hash"] for m in registry} 
+
+mesh_db = pooch.create(
+    # Use the default cache folder for the operating system
+    path=pooch.os_cache("mosaic"),
+    # The remote data is from LCRC
+    base_url="https://web.lcrc.anl.gov/public/e3sm",
+    version=__version__, 
+    # If this is a development version, get the data from the "main" branch
+    version_dev="main",
+    registry=_registry)
+
+# idea borrowed/copied from xarray
+def open_dataset(
+    name: str,
+    cache: bool = True,
+    **kws,
+) -> Dataset:
+    """
+    Open a dataset from the lcrc database (requires internet), unless a local 
+    copy is found. 
+    
+    Available datasets:
+
+    * ``"QU.960km"`` : ...
+    * ``"mpaso.EC30to60E2r3"`` : ...
+    * ``"mpasli.AIS8to30"`` : ...
+
+    Parameters
+    ----------
+    name : str
+        Name of the file containing the dataset.
+        e.g. 'air_temperature'
+    cache : bool, optional
+        If True, then cache data locally for use on subsequent calls
+    **kws : dict, optional
+        Passed to xarray.open_dataset
+    """
+
+    # invalid dataset name requested
+    if name not in registry:
+        raise FileNotFoundError(f"Requsted dataset \"{name}\" cannot be found")
+    
+    # use human readable registry to find filepath on lcrc
+    lcrc_path = registry[name]["lcrc_path"]
+    # retrive the file using pooch
+    filepath = mesh_db.fetch(lcrc_path)
+    
+    # open dataset
+    ds = xr.open_dataset(filepath, **kws)
+
+    # if `cache==False` persist file in memory and delete the downloaded file
+    if not cache: 
+        ds = ds.load()
+        pathlib.Path(filepath).unlink()
+
+    return ds

--- a/mosaic/datasets.py
+++ b/mosaic/datasets.py
@@ -20,9 +20,9 @@ registry = {
         "sha256_hash": "sha256:a3758f88ceff3d91e86dba7922f6dd7d5672157b4793ef78214624ab8b2724ae"
     },
 
-    "mpaso.EC30to60E2r3": {
-        "lcrc_path": "inputdata/ocn/mpas-o/EC30to60E2r3/mpaso.EC30to60E2r3.230313.nc",
-        "sha256_hash": "sha256:55e7cc33c890f7b9f1188bcc07fd8218b57cb1cd5ba32ee66fe3162a36995a7c"
+    "mpaso.IcoswISC30E3r5": {
+        "lcrc_path": "inputdata/share/meshes/mpas/ocean/IcoswISC30E3r5.20231120.nc",
+        "sha256_hash": "sha256:970afa546aa1e219b45234ae0bc8f5d4f41849cb42e6292abfd75ac89a561faf"
     },
 
     "mpasli.AIS8to30": {
@@ -60,7 +60,7 @@ def open_dataset(
 
     * ``"QU.960km"`` : Quasi-uniform spherical mesh, with approximately 960km horizontal resolution
     * ``"QU.240km"`` : Quasi-uniform spherical mesh, with approximately 240km horizontal resolution
-    * ``"mpaso.EC30to60E2r3"`` : (E)ddy-(C)losure 30 to 60 km MPAS-Ocean mesh
+    * ``"mpaso.IcoswISC30E3r5"`` : Icosahedral 30 km MPAS-Ocean mesh with ice shelf cavaties
     * ``"mpasli.AIS8to30"`` : 8-30 km resolution planar non-periodic MALI mesh of Antarctica
 
     Parameters

--- a/mosaic/datasets.py
+++ b/mosaic/datasets.py
@@ -5,8 +5,6 @@ import pooch
 import xarray as xr
 from xarray import Dataset
 
-from mosaic.version import __version__
-
 # this dictionary uses the short handed mesh names for convience,
 # but can not be parsed by pooch
 registry = {
@@ -39,9 +37,6 @@ mesh_db = pooch.create(
     path=pooch.os_cache("mosaic"),
     # The remote data is from LCRC
     base_url="https://web.lcrc.anl.gov/public/e3sm",
-    version=__version__,
-    # If this is a development version, get the data from the "main" branch
-    version_dev="main",
     registry=_registry)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "pooch",
     "pyproj",
     "scipy",
+    "tqdm",
     "xarray",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "netcdf4",
     "matplotlib",
     "numpy",
+    "pooch",
     "pyproj",
     "scipy",
     "xarray",


### PR DESCRIPTION
This PR adds a `datasets` module that handles the downloading and reading of various test meshes from the LCRC database. This module will be useful for both documentation/examples and future unit testing. The `mosaic.datasets.open_dataset` function has been added to the API documentation. 

A future PR will update the documentation to make use of the `datasets` module, to automatically download and read the meshes in the code examples. This will allow the documentation examples to be fully "copy and paste-able". 

