### PR TITLE
Set masked value as `-1` for out of bounds indicies.

### DIFF
--- a/mosaic/descriptor.py
+++ b/mosaic/descriptor.py
@@ -83,7 +83,7 @@ class Descriptor:
             # get mask of where index is out bounds
             mask = ds[array_name] == maxSize
             # where index is out of bounds, set to invalid (i.e. -1)
-            ds[array_name] = xr.where(mask, 1, ds[array_name])
+            ds[array_name] = xr.where(mask, -1, ds[array_name])
 
             return ds
 


### PR DESCRIPTION
Closes #10 by fixing bug introduced by #8. 

During linting the out of bounds mask value accidentally switched to `1` instead of `-1`, which caused a problem in patch creation (#10). This PR correct the out of bounds value. 