### PR TITLE
Improve patch creation along culled mesh boundaries 

### DIFF
--- a/mosaic/descriptor.py
+++ b/mosaic/descriptor.py
@@ -254,16 +254,22 @@ def _compute_cell_patches(ds):
     return verts
 
 
-def _compute_edge_patches(ds, latlon=False):
+def _compute_edge_patches(ds):
+    """Create edge patches for an MPAS mesh.
+
+    Edge patches have four nodes which typically correspond to the two cell
+    centers of the `cellsOnEdge` and the two vertices which make up the edge.
+    For an edge patch along a culled mesh boundary one of the cell centers
+    usually used to construct the patch will be missing, so the corresponding
+    node will be collapsed to the edge coordinate.
+    """
 
     # connectivity arrays have already been zero indexed
     cellsOnEdge = ds.cellsOnEdge
     verticesOnEdge = ds.verticesOnEdge
-
-    # this mask will never be true along the first column
-    # otherwise it's not an edge it's just a point
-    # that isn't possible (right?)
-    cellMask = cellsOnEdge[:, 1] < 0
+    # condition can only be true once per row or else wouldn't be an edge,
+    # which is why we use `np.any` along the first axis
+    cellMask = np.any(cellsOnEdge < 0, axis=1)
 
     # get subset of cell coordinate arrays corresponding to edge patches
     xCell = ds.xCell.values[cellsOnEdge]

--- a/mosaic/descriptor.py
+++ b/mosaic/descriptor.py
@@ -96,8 +96,8 @@ class Descriptor:
         # list of coordinate / connectivity arrays needed to create patches
         mesh_arrays = coordinate_arrays + connectivity_arrays
 
-        # get the subset of arrays from the mesh dataset
-        minimal_ds = ds[mesh_arrays]
+        # get subset of arrays from mesh and load into memory if dask arrays
+        minimal_ds = ds[mesh_arrays].load()
 
         # delete the attributes in the minimal dataset to avoid confusion
         minimal_ds.attrs.clear()

--- a/mosaic/descriptor.py
+++ b/mosaic/descriptor.py
@@ -49,6 +49,7 @@ class Descriptor:
         self.latlon = use_latlon
         self.projection = projection
         self.transform = transform
+        self._pre_projected = False
 
         # if mesh is on a sphere, force the use of lat lon coords
         if ds.attrs["on_a_sphere"].strip().upper() == 'YES':
@@ -61,6 +62,7 @@ class Descriptor:
         # reproject the minimal dataset, even for non-spherical meshes
         if projection and transform:
             self._transform_coordinates(projection, transform)
+            self._pre_projected = True
 
     def create_minimal_dataset(self, ds):
         """
@@ -138,6 +140,17 @@ class Descriptor:
         patches = _compute_vertex_patches(self.ds)
         patches = self._fix_antimeridian(patches, "Vertex")
         return patches
+
+    def get_transform(self):
+        """
+        """
+
+        if self._pre_projected:
+            transform = self.projection
+        else:
+            transform = self.transform
+
+        return transform
 
     def _transform_coordinates(self, projection, transform):
         """

--- a/mosaic/descriptor.py
+++ b/mosaic/descriptor.py
@@ -232,20 +232,23 @@ class Descriptor:
 
 def _compute_cell_patches(ds):
 
+    # get the maximum number of edges on a cell
+    maxEdges = ds.sizes["maxEdges"]
     # connectivity arrays have already been zero indexed
     verticesOnCell = ds.verticesOnCell
     # get a mask of the active vertices
     mask = verticesOnCell == -1
 
-    # get the coordinates needed to patch construction
-    xVertex = ds.xVertex
-    yVertex = ds.yVertex
+    # tile the first vertices index
+    firstVertex = np.tile(verticesOnCell[:, 0], (maxEdges, 1)).T
+    # set masked vertices to the first vertex of the cell
+    verticesOnCell = np.where(mask, firstVertex, verticesOnCell)
 
     # reshape/expand the vertices coordinate arrays
-    x_vert = np.ma.MaskedArray(xVertex[verticesOnCell], mask=mask)
-    y_vert = np.ma.MaskedArray(yVertex[verticesOnCell], mask=mask)
+    x_vert = ds.xVertex.values[verticesOnCell]
+    y_vert = ds.yVertex.values[verticesOnCell]
 
-    verts = np.ma.stack((x_vert, y_vert), axis=-1)
+    verts = np.stack((x_vert, y_vert), axis=-1)
 
     return verts
 

--- a/mosaic/descriptor.py
+++ b/mosaic/descriptor.py
@@ -337,16 +337,23 @@ def _compute_vertex_patches(ds):
     xVertex = ds.xVertex.values[:, np.newaxis]
     yVertex = ds.yVertex.values[:, np.newaxis]
 
-    # if edge is missing collapse node to vertex, otherwise node is at edge
+    # if edge is missing collapse edge node to vertex, else leave at edge
     nodes[:, ::2, 0] = np.where(edgeMask, xVertex, xEdge[edgesOnVertex])
     nodes[:, ::2, 1] = np.where(edgeMask, yVertex, yEdge[edgesOnVertex])
 
-    # if cell is missing collapse node to vertex, otherwise node is at cell
+    # if cell is missing collapse cell node to vertex, else leave at cell
     nodes[:, 1::2, 0] = np.where(cellMask, xVertex, xCell[cellsOnVertex])
     nodes[:, 1::2, 1] = np.where(cellMask, yVertex, yCell[cellsOnVertex])
 
-    # if cell and edge missing collapse node to vertex, otherwise leave at edge
-    nodes[:, 1::2, 0] = np.where(unionMask, xVertex, nodes[:, 1::2, 0])
-    nodes[:, 1::2, 1] = np.where(unionMask, yVertex, nodes[:, 1::2, 1])
+    # -------------------------------------------------------------------------
+    # NOTE: While the condition below probably only applies to the final edge
+    #       node we apply it to all, since the conditions above ensure the
+    #       patches will still be created correctly
+    # -------------------------------------------------------------------------
+    # if cell and edge missing collapse edge node to the first edge.
+    # Because edges lead the vertices this ensures the patch encompasses
+    # the full kite area and is propely closed.
+    nodes[:, ::2, 0] = np.where(unionMask, nodes[:, 0:1, 0], nodes[:, ::2, 0])
+    nodes[:, ::2, 1] = np.where(unionMask, nodes[:, 0:1, 1], nodes[:, ::2, 1])
 
     return nodes

--- a/mosaic/descriptor.py
+++ b/mosaic/descriptor.py
@@ -253,12 +253,12 @@ def _compute_cell_patches(ds):
     verticesOnCell = np.where(mask, firstVertex, verticesOnCell)
 
     # reshape/expand the vertices coordinate arrays
-    x_vert = ds.xVertex.values[verticesOnCell]
-    y_vert = ds.yVertex.values[verticesOnCell]
+    x_nodes = ds.xVertex.values[verticesOnCell]
+    y_nodes = ds.yVertex.values[verticesOnCell]
 
-    verts = np.stack((x_vert, y_vert), axis=-1)
+    nodes = np.stack((x_nodes, y_nodes), axis=-1)
 
-    return verts
+    return nodes
 
 
 def _compute_edge_patches(ds):
@@ -290,15 +290,15 @@ def _compute_edge_patches(ds):
         xCell = np.where(cellMask, ds.xEdge.values[:, np.newaxis], xCell)
         yCell = np.where(cellMask, ds.yEdge.values[:, np.newaxis], yCell)
 
-    x_vert = np.stack((xCell[:, 0], xVertex[:, 0],
-                       xCell[:, 1], xVertex[:, 1]), axis=-1)
+    x_nodes = np.stack((xCell[:, 0], xVertex[:, 0],
+                        xCell[:, 1], xVertex[:, 1]), axis=-1)
 
-    y_vert = np.stack((yCell[:, 0], yVertex[:, 0],
-                       yCell[:, 1], yVertex[:, 1]), axis=-1)
+    y_nodes = np.stack((yCell[:, 0], yVertex[:, 0],
+                        yCell[:, 1], yVertex[:, 1]), axis=-1)
 
-    verts = np.stack((x_vert, y_vert), axis=-1)
+    nodes = np.stack((x_nodes, y_nodes), axis=-1)
 
-    return verts
+    return nodes
 
 
 def _compute_vertex_patches(ds):
@@ -319,8 +319,7 @@ def _compute_vertex_patches(ds):
     nVertices = ds.sizes["nVertices"]
     vertexDegree = ds.sizes["vertexDegree"]
 
-    # TODO: rename to nodes
-    verts = np.zeros((nVertices, vertexDegree * 2, 2))
+    nodes = np.zeros((nVertices, vertexDegree * 2, 2))
     # connectivity arrays have already been zero indexed
     cellsOnVertex = ds.cellsOnVertex.values
     edgesOnVertex = ds.edgesOnVertex.values
@@ -339,15 +338,15 @@ def _compute_vertex_patches(ds):
     yVertex = ds.yVertex.values[:, np.newaxis]
 
     # if edge is missing collapse node to vertex, otherwise node is at edge
-    verts[:, ::2, 0] = np.where(edgeMask, xVertex, xEdge[edgesOnVertex])
-    verts[:, ::2, 1] = np.where(edgeMask, yVertex, yEdge[edgesOnVertex])
+    nodes[:, ::2, 0] = np.where(edgeMask, xVertex, xEdge[edgesOnVertex])
+    nodes[:, ::2, 1] = np.where(edgeMask, yVertex, yEdge[edgesOnVertex])
 
     # if cell is missing collapse node to vertex, otherwise node is at cell
-    verts[:, 1::2, 0] = np.where(cellMask, xVertex, xCell[cellsOnVertex])
-    verts[:, 1::2, 1] = np.where(cellMask, yVertex, yCell[cellsOnVertex])
+    nodes[:, 1::2, 0] = np.where(cellMask, xVertex, xCell[cellsOnVertex])
+    nodes[:, 1::2, 1] = np.where(cellMask, yVertex, yCell[cellsOnVertex])
 
     # if cell and edge missing collapse node to vertex, otherwise leave at edge
-    verts[:, 1::2, 0] = np.where(unionMask, xVertex, verts[:, 1::2, 0])
-    verts[:, 1::2, 1] = np.where(unionMask, yVertex, verts[:, 1::2, 1])
+    nodes[:, 1::2, 0] = np.where(unionMask, xVertex, nodes[:, 1::2, 0])
+    nodes[:, 1::2, 1] = np.where(unionMask, yVertex, nodes[:, 1::2, 1])
 
-    return verts
+    return nodes


### PR DESCRIPTION
This PR improves the (edge/vertex) patch creation along culled mesh boundaries. When a cell (and it's associated edges/vertices) has been culled, this PR will ensure the patch creation properly accounts for the missing nodes and that the resulting patches follow/match the culled boundary. 

Additionally this PR removes the use of numpy masked arrays, which cause problems `cartopy` wrapping. For ragged cell patches (i.e. cells where  `nEdgesOnCell` < `maxEdges`), the first vertex is repeat to ensure the patch is properly closed. The switch away from numpy mask arrays also mean mesh datasets comprised of dask arrays are now also supported, by persisting the needed coordinate/connectivity arrays into memory when the minimal dataset attribute of the `Descriptor` class is assembled.  

Finally, this PR fixes #14 by setting the collection transform when using a `GeoAxes`. 