### PR TITLE
Add build workflow to CI

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -1,0 +1,122 @@
+name: CI/CD Build Workflow
+
+on:
+  push:
+    branches: [main]
+
+  pull_request:
+    branches: [main]
+
+  workflow_dispatch:
+
+env:
+  CANCEL_OTHERS: false
+  PATHS_IGNORE: '["**/README.md", "**/docs/**"]'
+
+jobs:
+  pre-commit-hooks:
+    name: lint with pre-commit
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          cancel_others: ${{ env.CANCEL_OTHERS }}
+          paths_ignore: ${{ env.PATHS_IGNORE }}
+
+      - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+        name: Checkout Code Repository
+        uses: actions/checkout@v4
+
+      - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+        name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+        id: file_changes
+        uses: trilom/file-changes-action@1.2.4
+        with:
+          output: ' '
+
+      - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+        # Run all pre-commit hooks on all the files.
+        # Getting only staged files can be tricky in case a new PR is opened
+        # since the action is run on a branch in detached head state
+        name: Install and Run Pre-commit
+        uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: --files ${{ steps.file_changes.outputs.files}}
+
+  build:
+    name: test mosaic - python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        shell: bash -l {0}
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          cancel_others: ${{ env.CANCEL_OTHERS }}
+          paths_ignore: ${{ env.PATHS_IGNORE }}
+
+      - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+        uses: actions/checkout@v4
+
+      - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+        name: Cache Conda
+        uses: actions/cache@v4
+        env:
+          # Increase this value to reset cache if conda-dev-spec.template has not changed in the workflow
+          CACHE_NUMBER: 0
+        with:
+          path: ~/conda_pkgs_dir
+          key:
+            ${{ runner.os }}-${{ matrix.python-version }}-conda-${{ env.CACHE_NUMBER }}-${{
+            hashFiles('spec-file.txt,pyproject.toml,') }}
+
+      - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+        name: Set up Conda Environment
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          activate-environment: "mosaic_ci"
+          miniforge-version: latest
+          channels: conda-forge
+          channel-priority: strict
+          auto-update-conda: true
+          python-version: ${{ matrix.python-version }}
+
+      - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+        name: Install mosaic
+        run: |
+          conda create -n mosaic_dev --file dev-environment.txt \
+              python=${{ matrix.python-version }}
+          conda activate mosaic_dev
+          python -m pip install --no-deps --no-build-isolation -vv -e .
+
+      - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+        name: Run Tests
+        env:
+           CHECK_IMAGES: False
+        run: |
+          set -e
+          conda activate mosaic_dev
+          pip check
+          python -c "import mosaic"
+          #pytest tests
+
+      - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+        name: Build Sphinx Docs
+        run: |
+          set -e
+          conda activate mosaic_dev
+          pip check
+          cd docs
+          make html

--- a/dev-environment.txt
+++ b/dev-environment.txt
@@ -1,4 +1,4 @@
-python >= 3.9
+python >= 3.10
 cartopy
 cmocean
 h5netcdf

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 description = "A visualization package for MPAS meshes"
 license = {file = "LICENSE"}
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: BSD License",


### PR DESCRIPTION
This PR adds a build workflow, following `mache`, which iterates over all the supported python version. Hopefully this will catch some build errors, before they would occur in the conda forge build step. 

Fixes #17 and fixes #18. 