### PR TITLE
Add support for planar periodic meshes 

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -110,7 +110,7 @@ jobs:
           conda activate mosaic_dev
           pip check
           python -c "import mosaic"
-          pytest tests -v
+          #pytest tests -v
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Build Sphinx Docs

--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -110,7 +110,7 @@ jobs:
           conda activate mosaic_dev
           pip check
           python -c "import mosaic"
-          #pytest tests -v
+          pytest tests -v
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Build Sphinx Docs

--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -110,7 +110,7 @@ jobs:
           conda activate mosaic_dev
           pip check
           python -c "import mosaic"
-          #pytest tests
+          pytest tests -v
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Build Sphinx Docs

--- a/dev-environment.txt
+++ b/dev-environment.txt
@@ -8,6 +8,7 @@ numpy
 pooch
 pyproj
 scipy
+shapely
 tqdm
 xarray
 

--- a/dev-environment.txt
+++ b/dev-environment.txt
@@ -17,6 +17,7 @@ setuptools >=60
 # Linting and tesing
 pip
 pytest
+pytest-timeout
 isort
 flake8
 mypy

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,6 +64,7 @@ intersphinx_mapping = {
         'matplotlib': ('https://matplotlib.org/stable', None),
         'numpy': ('https://numpy.org/doc/stable', None),
         'python': ('https://docs.python.org/3/', None),
+        'shapely': ('https://shapely.readthedocs.io/en/stable/', None),
         'xarray': ('https://xarray.pydata.org/en/stable', None),
         }
 

--- a/docs/developers_guide/api.md
+++ b/docs/developers_guide/api.md
@@ -39,4 +39,10 @@ Properties
     Descriptor.vertex_patches
     Descriptor.transform
 
+Helper Functions
+----------------
+.. autosummary::
+    :toctree: generated/
+
+    utils.get_invalid_patches
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@ Currently `mosaic` only supports [MPAS](https://mpas-dev.github.io/) meshes, but
 :caption: User Guide:
 
 user_guide/quick_start
+user_guide/wrapping
 ```
 
 ```{toctree}

--- a/docs/user_guide/quick_start.md
+++ b/docs/user_guide/quick_start.md
@@ -35,7 +35,7 @@ ds = mosaic.datasets.open_dataset("QU.240km")
 # define a map projection for our figure
 projection = ccrs.InterruptedGoodeHomolosine()
 # define the transform that describes our dataset
-transform = ccrs.PlateCarree()
+transform = ccrs.Geodetic()
 
 # create the figure and a GeoAxis 
 fig, ax = plt.subplots(1, 1, figsize=(9,7), facecolor="w",
@@ -54,13 +54,16 @@ ax.coastlines()
 fig.colorbar(collection, fraction=0.1, shrink=0.5, label="Cell Index");
 ```
 
-### Planar Non-Periodic 
+For more information about how spherical meshes are handled and a list of supported
+map projections, see: <project:#wrapping>.
+
+### Planar Non-Periodic
 
 In this case the underlying coordinate arrays (i.e. `xCell/yCell`)
 correspond to a South Polar Stereographic projection, which is also the map projection we
 want to us. Therefore, the `projection` and the `transform` will be equivalent
 for this example. When instantiating the `mosaic.Descriptor` object we have to 
-careful to set `use_latlon=False` to ensure the `xCell`/`yCell` coordinate
+be careful to set `use_latlon=False` to ensure the `xCell`/`yCell` coordinate
 arrays are parsed (c.f. `lonCell`/`latCell`). 
 
 ```{code-cell} ipython3
@@ -101,13 +104,13 @@ fig.colorbar(collection, fraction=0.1, label="Thickness [m]");
 In the case where we do not know what projection the coordinate arrays of the
 mesh correspond to we can use the `lonCell`/`latCell` coordinates and `mosaic`
 will handle the transformation to the requested map projection under the hood.
-In this scenario the `transform` should correspond to `ccrs.PlateCarree()`
+In this scenario the `transform` should correspond to `ccrs.Geodetic()`
 and `use_latlon=True` must be set in the `mosaic.Descriptor` object
 instantiation. Nearly all the lines would be the same as the above example,
 with the exception of the transform definition: 
 ```python 
 # define the transform that describes our dataset
-transform = ccrs.PlateCarree()
+transform = ccrs.Geodetic()
 ```
 and the `mosaic.Descriptor` instantiation: 
 ```python

--- a/docs/user_guide/wrapping.md
+++ b/docs/user_guide/wrapping.md
@@ -1,0 +1,78 @@
+---
+file_format: mystnb
+kernelspec:
+  name: python3
+---
+
+# Periodic Mesh Support
+
+We currently make the simplifying assumption that spherical meshes are a
+special instance of periodic meshes, which are periodic across the antimeridian.
+We support both planar periodic and map projected spherical meshes, using the
+same methods, by assuming that the period (in the x and y directions
+respectively) is constant. This assumption is valid for planar periodic meshes
+and for some map projections, but falls apart for certain map projection where
+the antimeridian does not follow a strait line. Therefore we only support a
+subset of `cartopy` projections, which are listed below. Future work will
+develop a more elaborate method of dealing with spherical mesh periodicity,
+which in turn will expand the list supported map projections.
+
+For patches that cross a periodic boundary we simply correct the coordinates to
+remove the periodicity, which enables plotting. Future work will mirror the
+patches across the periodic boundary, so as to more accurately demonstrate the
+periodic nature of the mesh.
+
+<!-- 
+## Planar Periodic Meshes
+
+```{code-cell} ipython3
+---
+mystnb:
+    remove_code_source: true
+---
+import mosaic
+import matplotlib.pyplot as plt
+
+# download and read the mesh from lcrc
+ds = mosaic.datasets.open_dataset("doubly_periodic_4x4")
+
+# create the figure and a GeoAxis 
+fig, ax = plt.subplots(constrained_layout=True,)
+
+descriptor = mosaic.Descriptor(ds)
+
+pc = mosaic.polypcolor(
+    ax, descriptor, ds.indexToCellID, alpha=0.8, antialiaseds=True, ec="k"
+)
+
+ax.scatter(descriptor.ds.xCell, descriptor.ds.yCell, c='k')
+ax.scatter(*descriptor.cell_patches.T, c='tab:blue', marker='^')
+ax.scatter(ds.xVertex, ds.yVertex, ec='tab:orange', fc='none', marker='o', s=5.)
+ax.set_aspect('equal')
+```
+-->
+
+## Supported Map Projections for Spherical Meshes
+
+Currently, the only support map projection are:
+- <inv:#*.PlateCarree>
+- <inv:#*.LambertCylindrical>
+- <inv:#*.Mercator>
+- <inv:#*.Miller>
+- <inv:#*.Robinson>
+- <inv:#*.Stereographic>
+- <inv:#*.RotatedPole>
+- <inv:#*.InterruptedGoodeHomolosine>
+- <inv:#*.EckertI>
+- <inv:#*.EckertII>
+- <inv:#*.EckertIII>
+- <inv:#*.EckertIV>
+- <inv:#*.EckertV>
+- <inv:#*.EckertVI>
+- <inv:#*.EqualEarth>
+- <inv:#*.NorthPolarStereo>
+- <inv:#*.SouthPolarStereo>
+
+It is important to note that planer (non-periodic) meshes are not limited to
+this of map projections and can choose from the full list of `cartopy`
+[projections](https://scitools.org.uk/cartopy/docs/latest/reference/projections.html).

--- a/docs/user_guide/wrapping.md
+++ b/docs/user_guide/wrapping.md
@@ -74,5 +74,5 @@ Currently, the only support map projection are:
 - <inv:#*.SouthPolarStereo>
 
 It is important to note that planer (non-periodic) meshes are not limited to
-this of map projections and can choose from the full list of `cartopy`
+this list of map projections and can choose from the full list of `cartopy`
 [projections](https://scitools.org.uk/cartopy/docs/latest/reference/projections.html).

--- a/mosaic/datasets.py
+++ b/mosaic/datasets.py
@@ -26,7 +26,12 @@ registry = {
     "mpasli.AIS8to30": {
         "lcrc_path": "inputdata/glc/mpasli/mpas.ais8to30km/ais_8to30km.20221027.nc",
         "sha256_hash": "sha256:932a1989ff8e51223413ef3ff0056d6737a1fc7f53e440359884a567a93413d2"
-    }
+    },
+
+    "doubly_periodic_4x4": {
+        "lcrc_path": "mpas_standalonedata/mpas-ocean/mesh_database/doubly_periodic_1920km_7680x7680km.151124.nc",
+        "sha256_hash": "sha256:5409d760845fb682ec56e30d9c6aa6dfe16b5d0e0e74f5da989cdaddbf4303c7"
+    },
 }
 
 # create a parsable registry for pooch from human friendly one
@@ -55,8 +60,9 @@ def open_dataset(
 
     * ``"QU.960km"`` : Quasi-uniform spherical mesh, with approximately 960km horizontal resolution
     * ``"QU.240km"`` : Quasi-uniform spherical mesh, with approximately 240km horizontal resolution
-    * ``"mpaso.IcoswISC30E3r5"`` : Icosahedral 30 km MPAS-Ocean mesh with ice shelf cavaties
+    * ``"mpaso.IcoswISC30E3r5"`` : Icosahedral 30 km MPAS-Ocean mesh with ice shelf cavities
     * ``"mpasli.AIS8to30"`` : 8-30 km resolution planar non-periodic MALI mesh of Antarctica
+    * ``"doubly_periodic_4x4"``: Doubly periodic planar mesh that is four cells wide in both the x and y dimensions.
 
     Parameters
     ----------

--- a/mosaic/descriptor.py
+++ b/mosaic/descriptor.py
@@ -21,12 +21,12 @@ connectivity_arrays = ["cellsOnEdge",
                        "verticesOnCell",
                        "edgesOnVertex"]
 
-SUPPORTED_PROJECTIONS = (ccrs._RectangularProjection,
-                         ccrs._WarpedRectangularProjection,
-                         ccrs.Stereographic,
-                         ccrs.Mercator,
-                         ccrs._CylindricalProjection,
-                         ccrs.InterruptedGoodeHomolosine)
+SUPPORTED_SPHERICAL_PROJECTIONS = (ccrs._RectangularProjection,
+                                   ccrs._WarpedRectangularProjection,
+                                   ccrs.Stereographic,
+                                   ccrs.Mercator,
+                                   ccrs._CylindricalProjection,
+                                   ccrs.InterruptedGoodeHomolosine)
 
 
 def attr_to_bool(attr: str):
@@ -207,11 +207,12 @@ class Descriptor:
     def projection(self, projection: CRS) -> None:
         # We don't support all map projections for spherical meshes, yet...
         if (projection is not None and self.is_spherical and
-                not isinstance(projection, SUPPORTED_PROJECTIONS)):
+                not isinstance(projection, SUPPORTED_SPHERICAL_PROJECTIONS)):
 
             raise ValueError(f"Invalid projection: {type(projection).__name__}"
                              f" is not supported - consider using "
                              f"a rectangular projection.")
+
         # Issue warning if changing the projection after initialization
         # TODO: Add heuristic size (i.e. ``self.ds.nbytes``) above which the
         #       warning is raised
@@ -444,7 +445,7 @@ class Descriptor:
                 patches, loc, "y", self.y_period
             )
 
-            if np.any(x_mask):
+            if np.any(y_mask):
                 # using the sign of the difference correct patches y coordinate
                 patches = _wrap_1D(patches, y_mask, y_sign, 1, self.y_period)
 

--- a/mosaic/descriptor.py
+++ b/mosaic/descriptor.py
@@ -239,10 +239,11 @@ class Descriptor:
 
         # if periods are None (i.e. projection was not set at instantiation) or
         # the descriptor is being reprojected; update the periods
-        if (not self.x_period and not self.y_period) or reprojecting:
-            # dummy value b/c `self._projection` attr will be used by setters
-            self.x_period = None
-            self.y_period = None
+        if (hasattr(self, "_x_period") and hasattr(self, "_x_period")):
+            if (not self.x_period and not self.y_period) or reprojecting:
+                # dummy value b/c `_projection` attr will be used by setters
+                self.x_period = None
+                self.y_period = None
 
     @property
     def latlon(self) -> bool:

--- a/mosaic/descriptor.py
+++ b/mosaic/descriptor.py
@@ -429,7 +429,7 @@ class Descriptor:
             return patches
 
         if self.x_period:
-            # find the patch that are periodic in x-direction
+            # find the patches that are periodic in x-direction
             x_mask, x_sign = _find_boundary_patches(
                 patches, loc, "x", self.x_period
             )
@@ -439,7 +439,7 @@ class Descriptor:
                 patches = _wrap_1D(patches, x_mask, x_sign, 0, self.x_period)
 
         if self.y_period:
-            # find the patch that are periodic in y-direction
+            # find the patches that are periodic in y-direction
             y_mask, y_sign = _find_boundary_patches(
                 patches, loc, "y", self.y_period
             )
@@ -552,14 +552,14 @@ def _compute_vertex_patches(ds: Dataset) -> ndarray:
     nodes[:, 1::2, 1] = np.where(cellMask, yVertex, yCell[cellsOnVertex])
 
     # -------------------------------------------------------------------------
-    # NOTE: While the condition below probably only applies to the final edge
-    #       node we apply it to all, since the conditions above ensure the
-    #       patches will still be created correctly
+    # NOTE: The condition below will only be true for meshes run through the
+    #       MPAS mesh converter after culling. A bug in the converter alters
+    #       the ordering of edges, causing problems for vertex patches
     # -------------------------------------------------------------------------
-    # if cell and edge missing collapse edge node to the first edge.
+    # if cell and edge missing collapse final edge node to the first edge.
     # Because edges lead the vertices this ensures the patch encompasses
     # the full kite area and is properly closed.
-    nodes[:, ::2, 0] = np.where(unionMask, nodes[:, 0:1, 0], nodes[:, ::2, 0])
-    nodes[:, ::2, 1] = np.where(unionMask, nodes[:, 0:1, 1], nodes[:, ::2, 1])
+    nodes[:, 4, 0] = np.where(unionMask[:, -1], nodes[:, 0, 0], nodes[:, 4, 0])
+    nodes[:, 4, 1] = np.where(unionMask[:, -1], nodes[:, 0, 1], nodes[:, 4, 1])
 
     return nodes

--- a/mosaic/descriptor.py
+++ b/mosaic/descriptor.py
@@ -31,6 +31,14 @@ def attr_to_bool(attr: str):
             raise ValueError("f{attr} was unable to be parsed as YES/NO")
 
 
+def parse_period(period):
+    """ Parse period attribute, return None if period is zero """
+    if float(period) == 0.0:
+        return None
+    else:
+        return float(period)
+
+
 class Descriptor:
     """Data structure describing unstructured MPAS meshes.
 
@@ -105,8 +113,14 @@ class Descriptor:
         #: ``projection`` kwargs are provided.
         self.transform = transform
 
+        #: Boolean whether parent mesh is (planar) periodic in at least one dim
+        self.is_periodic = attr_to_bool(mesh_ds.is_periodic)
         #: Boolean whether parent mesh is spherical
         self.is_spherical = attr_to_bool(mesh_ds.on_a_sphere)
+        #: Period along x-dimension, is ``None`` for non-periodic meshes
+        self.x_period = parse_period(mesh_ds.x_period)
+        #: Period along y-dimension, is ``None`` for non-periodic meshes
+        self.y_period = parse_period(mesh_ds.y_period)
 
         # calls attribute setter method
         self.latlon = use_latlon

--- a/mosaic/polypcolor.py
+++ b/mosaic/polypcolor.py
@@ -1,3 +1,4 @@
+import numpy as np
 from cartopy.mpl.geoaxes import GeoAxes
 from matplotlib.axes import Axes
 from matplotlib.collections import PolyCollection
@@ -48,12 +49,18 @@ def polypcolor(
 
     if "nCells" in c.dims:
         verts = descriptor.cell_patches
+        if descriptor.projection and np.any(descriptor._cell_pole_mask):
+            c = c.where(~descriptor._cell_pole_mask, np.nan)
 
     elif "nEdges" in c.dims:
         verts = descriptor.edge_patches
+        if descriptor.projection and np.any(descriptor._edge_pole_mask):
+            c = c.where(~descriptor._edge_pole_mask, np.nan)
 
     elif "nVertices" in c.dims:
         verts = descriptor.vertex_patches
+        if descriptor.projection and np.any(descriptor._vertex_pole_mask):
+            c = c.where(~descriptor._vertex_pole_mask, np.nan)
 
     transform = descriptor.transform
 

--- a/mosaic/utils.py
+++ b/mosaic/utils.py
@@ -1,0 +1,44 @@
+from typing import Literal
+
+import numpy as np
+from shapely import LineString, is_valid
+
+from mosaic.descriptor import Descriptor
+
+
+def get_invalid_patches(
+    descriptor: Descriptor, location: Literal["cell", "edge", "vertex"]
+) -> None | np.ndarray:
+    """Helper function to identify problematic patches.
+
+    Returns the indices of the problematic patches as determined by
+    :py:func:`shapely.is_valid`.
+
+    Parameters
+    ----------
+    descriptor : :py:class:`Descriptor`
+        The ``Descriptor`` object you want to check the patches of
+    location : string
+        The patch location to check: "cell" or "edge" or "vertex"
+
+    Returns
+    -------
+    :py:class:`~numpy.ndarray` or None
+        Indices of invalid patches. If no patches are invalid then returns None
+    """
+    # extract the patches
+    patches = descriptor.__getattribute__(f"{location}_patches")
+    # get the pole mask b/c we know patches will be invalid there
+    pole_mask = descriptor.__getattribute__(f"_{location}_pole_mask")
+    # convert the patches to a list of shapely geometries
+    geoms = [LineString(patch) for patch in patches[~pole_mask]]
+    # check if the shapely geometries are valid
+    valid = is_valid(geoms)
+
+    if np.all(valid):
+        # no invalid patches, so return None
+        return None
+    else:
+        # return the indices of the invalid patches
+        index_array = np.arange(patches.shape[0])
+        return index_array[~pole_mask][~valid]

--- a/tests/test_spherical.py
+++ b/tests/test_spherical.py
@@ -43,7 +43,7 @@ class TestSphericalWrapping:
         descriptor = mosaic.Descriptor(self.ds, request.param, ccrs.Geodetic())
         return descriptor
 
-    @pytest.mark.timeout(75)
+    @pytest.mark.timeout(30)
     @pytest.mark.parametrize("patch", ["Cell", "Edge", "Vertex"])
     @pytest.mark.filterwarnings("ignore:numpy.ndarray size changed")
     def test_timeout(self, setup_descriptor, tmp_path, patch):

--- a/tests/test_spherical.py
+++ b/tests/test_spherical.py
@@ -34,51 +34,52 @@ def id_func(projection):
     return type(projection).__name__
 
 
-@pytest.fixture(scope="module", params=SUPPORTED_PROJECTIONS, ids=id_func)
-def setup_descriptor(request):
+class TestSphericalWrapping:
+
     ds = mosaic.datasets.open_dataset("QU.240km")
-    descriptor = mosaic.Descriptor(ds, request.param, ccrs.Geodetic())
-    return ds, descriptor
 
+    @pytest.fixture(scope="module", params=SUPPORTED_PROJECTIONS, ids=id_func)
+    def setup_descriptor(self, request):
+        descriptor = mosaic.Descriptor(self.ds, request.param, ccrs.Geodetic())
+        return descriptor
 
-@pytest.mark.timeout(30)
-@pytest.mark.parametrize("patch", ["Cell", "Edge", "Vertex"])
-@pytest.mark.filterwarnings("ignore:numpy.ndarray size changed")
-def test_timeout(setup_descriptor, tmp_path, patch):
-    # do the test setup with the parameterized projection
-    ds, descriptor = setup_descriptor
+    @pytest.mark.timeout(30)
+    @pytest.mark.parametrize("patch", ["Cell", "Edge", "Vertex"])
+    @pytest.mark.filterwarnings("ignore:numpy.ndarray size changed")
+    def test_timeout(self, setup_descriptor, tmp_path, patch):
+        # do the test setup with the parameterized projection
+        descriptor = setup_descriptor
 
-    projection = descriptor.projection
+        projection = descriptor.projection
 
-    # get the projection name
-    proj_name = type(projection).__name__
+        # get the projection name
+        proj_name = type(projection).__name__
 
-    # setup with figure with the parameterized projection
-    fig, ax = plt.subplots(subplot_kw=dict(projection=projection))
+        # setup with figure with the parameterized projection
+        fig, ax = plt.subplots(subplot_kw=dict(projection=projection))
 
-    # get the appropriate dataarray for the parameterized patch location
-    da = ds[f"indexTo{patch}ID"]
+        # get the appropriate dataarray for the parameterized patch location
+        da = self.ds[f"indexTo{patch}ID"]
 
-    # just testing that this doesn't hang, not for correctness
-    mosaic.polypcolor(ax, descriptor, da, antialiaseds=True)
+        # just testing that this doesn't hang, not for correctness
+        mosaic.polypcolor(ax, descriptor, da, antialiaseds=True)
 
-    # save the figure so that patches are rendered
-    fig.savefig(f"{tmp_path}/{proj_name}-{patch}.png")
-    plt.close()
+        # save the figure so that patches are rendered
+        fig.savefig(f"{tmp_path}/{proj_name}-{patch}.png")
+        plt.close()
 
+    @pytest.mark.parametrize("patch", ["Cell", "Edge"])
+    def test_valid_patches(self, setup_descriptor, patch):
+        # do the test setup with the parameterized projection
+        descriptor = setup_descriptor
 
-@pytest.mark.parametrize("patch", ["Cell", "Edge"])
-def test_valid_patches(setup_descriptor, patch):
-    # do the test setup with the parameterized projection
-    _, descriptor = setup_descriptor
+        # extract the patches
+        patches = descriptor.__getattribute__(f"{patch.lower()}_patches")
+        # get the pole mask b/c we know patches will be invalid there
+        pole_mask = descriptor.__getattribute__(f"_{patch.lower()}_pole_mask")
 
-    # extract the patches
-    patches = descriptor.__getattribute__(f"{patch.lower()}_patches")
-    # get the pole mask b/c we know patches will be invalid there
-    pole_mask = descriptor.__getattribute__(f"_{patch.lower()}_pole_mask")
+        # convert the patches to a list of shapely geometries
+        geoms = [LinearRing(patch) for patch in patches[~pole_mask]]
 
-    # convert the patches to a list of shapely geometries
-    geoms = [LinearRing(patch) for patch in patches[~pole_mask]]
-
-    # assert that all the patches are valid
-    assert np.all(is_valid(geoms))
+        # assert that all the patches are valid
+        assert np.all(is_valid(geoms))

--- a/tests/test_spherical.py
+++ b/tests/test_spherical.py
@@ -68,7 +68,7 @@ class TestSphericalWrapping:
         fig.savefig(f"{tmp_path}/{proj_name}-{patch}.png")
         plt.close()
 
-    @pytest.mark.parametrize("patch", ["Cell", "Edge"])
+    @pytest.mark.parametrize("patch", ["Cell", "Edge", "Vertex"])
     def test_valid_patches(self, setup_descriptor, patch):
         # do the test setup with the parameterized projection
         descriptor = setup_descriptor

--- a/tests/test_spherical.py
+++ b/tests/test_spherical.py
@@ -43,7 +43,7 @@ class TestSphericalWrapping:
         descriptor = mosaic.Descriptor(self.ds, request.param, ccrs.Geodetic())
         return descriptor
 
-    @pytest.mark.timeout(30)
+    @pytest.mark.timeout(75)
     @pytest.mark.parametrize("patch", ["Cell", "Edge", "Vertex"])
     @pytest.mark.filterwarnings("ignore:numpy.ndarray size changed")
     def test_timeout(self, setup_descriptor, tmp_path, patch):

--- a/tests/test_spherical.py
+++ b/tests/test_spherical.py
@@ -1,0 +1,84 @@
+import cartopy.crs as ccrs
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+from shapely import LinearRing, is_valid
+
+import mosaic
+
+matplotlib.use('Agg', force=True)
+
+SUPPORTED_PROJECTIONS = [
+    ccrs.PlateCarree(),
+    ccrs.LambertCylindrical(),
+    ccrs.Mercator(),
+    ccrs.Miller(),
+    ccrs.Robinson(),
+    ccrs.Stereographic(),
+    ccrs.RotatedPole(),
+    ccrs.InterruptedGoodeHomolosine(),
+    ccrs.EckertI(),
+    ccrs.EckertII(),
+    ccrs.EckertIII(),
+    ccrs.EckertIV(),
+    ccrs.EckertV(),
+    ccrs.EckertVI(),
+    ccrs.EqualEarth(),
+    ccrs.NorthPolarStereo(),
+    ccrs.SouthPolarStereo(),
+]
+
+
+def id_func(projection):
+    return type(projection).__name__
+
+
+@pytest.fixture(scope="module", params=SUPPORTED_PROJECTIONS, ids=id_func)
+def setup_descriptor(request):
+    ds = mosaic.datasets.open_dataset("QU.240km")
+    descriptor = mosaic.Descriptor(ds, request.param, ccrs.Geodetic())
+    return ds, descriptor
+
+
+@pytest.mark.timeout(30)
+@pytest.mark.parametrize("patch", ["Cell", "Edge", "Vertex"])
+@pytest.mark.filterwarnings("ignore:numpy.ndarray size changed")
+def test_timeout(setup_descriptor, tmp_path, patch):
+    # do the test setup with the parameterized projection
+    ds, descriptor = setup_descriptor
+
+    projection = descriptor.projection
+
+    # get the projection name
+    proj_name = type(projection).__name__
+
+    # setup with figure with the parameterized projection
+    fig, ax = plt.subplots(subplot_kw=dict(projection=projection))
+
+    # get the appropriate dataarray for the parameterized patch location
+    da = ds[f"indexTo{patch}ID"]
+
+    # just testing that this doesn't hang, not for correctness
+    mosaic.polypcolor(ax, descriptor, da, antialiaseds=True)
+
+    # save the figure so that patches are rendered
+    fig.savefig(f"{tmp_path}/{proj_name}-{patch}.png")
+    plt.close()
+
+
+@pytest.mark.parametrize("patch", ["Cell", "Edge"])
+def test_valid_patches(setup_descriptor, patch):
+    # do the test setup with the parameterized projection
+    _, descriptor = setup_descriptor
+
+    # extract the patches
+    patches = descriptor.__getattribute__(f"{patch.lower()}_patches")
+    # get the pole mask b/c we know patches will be invalid there
+    pole_mask = descriptor.__getattribute__(f"_{patch.lower()}_pole_mask")
+
+    # convert the patches to a list of shapely geometries
+    geoms = [LinearRing(patch) for patch in patches[~pole_mask]]
+
+    # assert that all the patches are valid
+    assert np.all(is_valid(geoms))


### PR DESCRIPTION
This PR adds support for planar periodic meshes, by streamlining and abstracting the spherical wrapping functionality so that it works to both planar and spherical meshes. For this to work, I've added getter/setter methods for the period attributes that handle the planar periodic / spherical meshes details appropriately. This has also dramatically simplified the spherical wrapping procedure, which was unduly complicated (and insufficient) previously. Testing of new the spherical wrapping for vertex patches has revealed a bug in #12, which produces invalid geometries for vertices along culled boundaries. When these invalid geometries intersect the map projection boundary, `cartopy` struggles with them resulting in the patches spanning the entire plot area. This bug is fixed as part of this PR. Finally, for testing purposes this PR also adds a small planar periodic mesh to the datasets database. 

Fixes #15. 