### PR TITLE
Pass norm kwarg to PolyCollection

### DIFF
--- a/mosaic/polypcolor.py
+++ b/mosaic/polypcolor.py
@@ -120,7 +120,7 @@ def polypcolor(
     vmax = kwargs.pop("vmax", None)
     norm = kwargs.pop("norm", None)
 
-    collection = PolyCollection(verts, array=array, **kwargs)
+    collection = PolyCollection(verts, array=array, norm=norm, **kwargs)
 
     # only set the transform if GeoAxes
     if isinstance(ax, GeoAxes):


### PR DESCRIPTION
Closes #44, which was introduced by #29. `norm` must be passed to the `Polycollection` instantiation. 

CC'ing @cbegeman, as this should fix the issues you've seen with mosaic `1.12.0` in polaris. 