### PR TITLE
Implement cell contouring on the native mesh

### DIFF
--- a/dev-environment.txt
+++ b/dev-environment.txt
@@ -17,6 +17,7 @@ xarray
 click
 jupyterlab
 hyperfine
+line_profiler
 mpas_tools
 
 # Building

--- a/dev-environment.txt
+++ b/dev-environment.txt
@@ -4,6 +4,7 @@ cmocean
 h5netcdf
 netcdf4
 matplotlib-base
+networkx
 numpy
 pooch
 pyproj
@@ -15,6 +16,7 @@ xarray
 # Development
 click
 jupyterlab
+hyperfine
 mpas_tools
 
 # Building

--- a/dev-environment.txt
+++ b/dev-environment.txt
@@ -31,6 +31,7 @@ isort
 flake8
 mypy
 pre-commit
+hypothesis
 
 # Documentation
 ipywidgets

--- a/dev-environment.txt
+++ b/dev-environment.txt
@@ -4,7 +4,6 @@ cmocean
 h5netcdf
 netcdf4
 matplotlib-base
-networkx
 numpy
 pooch
 pyproj
@@ -30,6 +29,7 @@ pytest-timeout
 isort
 flake8
 mypy
+networkx
 pre-commit
 hypothesis
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,6 +51,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
     "sphinx_remove_toctrees",
+    "matplotlib.sphinxext.roles",
 ]
 
 source_suffix = {
@@ -106,6 +107,7 @@ copybutton_prompt_text = ">>> "
 napoleon_google_docstring = False
 napoleon_numpy_docstring = True
 napoleon_preprocess_types = True
+napoleon_use_param = False
 napoleon_type_aliases = {
     "cartopy.crs.Projection": ":class:`cartopy.crs.CRS`",
     # objects without namespace: xarray

--- a/docs/developers_guide/api.md
+++ b/docs/developers_guide/api.md
@@ -26,6 +26,7 @@ Data Structures
     :toctree: generated/
 
     Descriptor
+    mosaic.contour.MPASContourSet
 
 Helper Functions
 ----------------

--- a/docs/developers_guide/api.md
+++ b/docs/developers_guide/api.md
@@ -10,34 +10,22 @@ API Reference
 
 This page provides an auto-generated summary of mosaic's API.
 
-Top Level Utilities
--------------------
+Plotting
+--------
 .. autosummary::
     :toctree: generated/
 
     polypcolor
-    Descriptor
-    datasets.open_dataset
+    contour
+    contourf
 
-Descriptor
-----------
+Data Structures
+---------------
 
-Constructor
-~~~~~~~~~~~
 .. autosummary::
     :toctree: generated/
 
     Descriptor
-
-Properties
-~~~~~~~~~~
-.. autosummary::
-    :toctree: generated/
-
-    Descriptor.cell_patches
-    Descriptor.edge_patches
-    Descriptor.vertex_patches
-    Descriptor.transform
 
 Helper Functions
 ----------------
@@ -47,4 +35,5 @@ Helper Functions
     utils.cull_mesh
     utils.get_invalid_patches
     utils.compute_cell_centroid
+    datasets.open_dataset
 ```

--- a/docs/developers_guide/design_docs.md
+++ b/docs/developers_guide/design_docs.md
@@ -1,0 +1,13 @@
+# Design Documents
+
+The pages contained within are intended to serve as somewhere between true "design documents"
+and a collection of notes taken *during* development. The hybrid nature of these notes is
+intended to document the decisions made during development and the test problems used to inform
+those decisions.
+
+```{toctree}
+:maxdepth: 1
+:caption: Design Documents:
+
+design_docs/contouring
+```

--- a/docs/developers_guide/design_docs/contouring.ipynb
+++ b/docs/developers_guide/design_docs/contouring.ipynb
@@ -1,0 +1,1637 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "hide-cell",
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "from __future__ import annotations\n",
+    "\n",
+    "import io\n",
+    "from contextlib import redirect_stdout\n",
+    "\n",
+    "import matplotlib.patches as mpatches\n",
+    "import matplotlib.path as mpath\n",
+    "import matplotlib.pyplot as plt\n",
+    "import networkx as nx\n",
+    "import numpy as np\n",
+    "from matplotlib import cm\n",
+    "from mpas_tools.mesh.conversion import convert, cull\n",
+    "from mpas_tools.planar_hex import make_planar_hex_mesh\n",
+    "from mpas_tools.translate import center\n",
+    "from mpl_toolkits.axes_grid1.inset_locator import inset_axes\n",
+    "\n",
+    "import mosaic\n",
+    "from mosaic.contour import MPASContourGenerator\n",
+    "\n",
+    "plt.rcParams[\"text.usetex\"] = True\n",
+    "\n",
+    "SIZE = 3.5\n",
+    "\n",
+    "\n",
+    "def gaussian(x, y, sigma=0.15, A=2.0):\n",
+    "    \"\"\" \"\"\"\n",
+    "    return A * np.exp(-1.0 * (x**2 / (2 * sigma**2) + y**2 / (2 * sigma**2)))\n",
+    "\n",
+    "\n",
+    "def sinusoid(x, y, A=2.0, N=1.5):\n",
+    "    \"\"\" \"\"\"\n",
+    "    x_min = np.min(x)\n",
+    "    y_min = np.min(y)\n",
+    "    x_max = np.max(x)\n",
+    "    y_max = np.max(y)\n",
+    "\n",
+    "    L_x = (x_max - x_min) / 2\n",
+    "    L_y = (y_max - y_min) / 2\n",
+    "    return A * np.sin(N * np.pi * (x / L_x)) * np.sin(N * np.pi * (y / L_y))\n",
+    "\n",
+    "\n",
+    "def planar_hex_mesh(N=100):\n",
+    "    \"\"\"Wrapper for MPAS-Tools functions\"\"\"\n",
+    "    output_capture = io.StringIO()\n",
+    "\n",
+    "    # Redirect stdout to the buffer within the 'with' block\n",
+    "    with redirect_stdout(output_capture):\n",
+    "        ds = make_planar_hex_mesh(\n",
+    "            nx=N, ny=N, dc=1 / N, nonperiodic_x=True, nonperiodic_y=True\n",
+    "        )\n",
+    "        ds = cull(ds)\n",
+    "        ds = convert(ds)\n",
+    "        # returns None, does centering inplace\n",
+    "        center(ds)\n",
+    "\n",
+    "    return ds\n",
+    "\n",
+    "\n",
+    "def single_pannel(figsize=(SIZE, SIZE)):\n",
+    "    fig, ax = plt.subplots(figsize=figsize, layout=\"constrained\")\n",
+    "    ax.set_aspect(\"equal\")\n",
+    "    ax.set_axis_off()\n",
+    "    return fig, ax\n",
+    "\n",
+    "\n",
+    "def double_pannel(figsize=(2 * SIZE, SIZE)):\n",
+    "    w, h = figsize\n",
+    "    figsize = (w + 0.1 / (2 / w), h)\n",
+    "\n",
+    "    fig, axes = plt.subplots(\n",
+    "        nrows=1,\n",
+    "        ncols=3,\n",
+    "        figsize=(figsize),\n",
+    "        layout=\"constrained\",\n",
+    "        width_ratios=[1, 0.1, 1],\n",
+    "    )\n",
+    "\n",
+    "    axes[1].plot([0 for i in range(10)], range(10), c=\"k\", lw=0.5)\n",
+    "\n",
+    "    for ax in axes:\n",
+    "        ax.set_axis_off()\n",
+    "        ax.set_aspect(\"equal\")\n",
+    "\n",
+    "    ax = axes[[0, 2]]\n",
+    "    ax[0].sharex(ax[1])\n",
+    "    ax[0].sharey(ax[1])\n",
+    "    return fig, ax"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# see: https://github.com/jupyterlab/jupyterlab/issues/9309\n",
+    "%config InlineBackend.figure_format = 'retina'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "# Contouring\n",
+    "\n",
+    "**Developer**: Andrew Nolan (github:[`andrewdnolan`](https://github.com/andrewdnolan/))\n",
+    "\n",
+    "## Overview\n",
+    "For complete visualization capabilities in `mosaic`, we need to be able to create contour and filled contour plots. Unfortunately, we are unable to use the existing [`matplotlib.pyplot.contour`](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.contour.html) and [`matplotlib.pyplot.contourf`](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.contourf.html) functions, due to two `matplotlib` requirements: \n",
+    "  1. That the `X` and `Y` coordinates arrays represent a regularly spaces, structured grid.\n",
+    "  2. That the `Z` data being contoured be coincidental with the `X` and `Y` coordinates on the mesh.\n",
+    "\n",
+    "The above requirements are enforced, because \"under the hood\" matplotlib uses the [`contourpy`](https://contourpy.readthedocs.io/) packages, which is a C++ implementation of the [marching squares](https://en.wikipedia.org/wiki/Marching_squares) algorithm. The unstrucuted nature of MPAS meshes prevents (1) from ever being satisfied. Because MPAS meshes represent control volumes, data are not defined at discrete \"nodes\" but over a control volumes, therefore preventing (2) from being easily satisfied. The analogous [marching triangles](https://en.wikipedia.org/wiki/Marching_squares#Contouring_triangle_meshes) algorithm could work for out unstructured data, but [`contourpy`](https://contourpy.readthedocs.io/) has not implemented it. From a cursory look, there do not seem to be any implementations of marching triangles, with a python interface, as mature and well mainted as the marching squares algorithm within [`contourpy`](https://contourpy.readthedocs.io/). \n",
+    "\n",
+    "Instead, we've opted to follow Andrew Robert's [`Ridgepack` MATLAB package](https://github.com/proteanplanet/Ridgepack) and use the mesh connectivity information to create contours of unstrucuted MPAS meshes. The implementation below follows `Ridgepack`, but we have opted to avoid a direct port of the MATLAB code. Instead we crib from the approach, but try to implement as much as possible using external python libraries to increase robustness and performance. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "## Rough Sketch of Implementation\n",
+    "\n",
+    "Let's start by considering a small ($20 \\times 20$ cell) planar non-periodic MPAS mesh. The initial field we will consider will be a 2D gaussian with an amplitude ($A$) of $2$ and standard deviation ($\\sigma$) of $0.15$:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "ds = planar_hex_mesh(20)\n",
+    "gauss = gaussian(ds.xCell, ds.yCell)\n",
+    "descriptor = mosaic.Descriptor(ds)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "remove-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "fig, ax = single_pannel()\n",
+    "\n",
+    "pc = mosaic.polypcolor(ax, descriptor, gauss, vmax=2, vmin=0, aa=True)\n",
+    "\n",
+    "fig.colorbar(pc, shrink=0.5, extend=\"both\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "**Figure 1.** Gaussian kernel with $A=2$ and $\\sigma=0.15$ evaluated on a $20\\times20$ cell planar non-periodic MPAS mesh. \n",
+    "\n",
+    "Now, let's contour the `1.0` level. Like \"Marching Squares\" algorithm, we'll start by creating a boolean mask of cells above and below the contour level. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "mask = gauss < 1.0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "edge_mask = np.logical_xor.reduce(\n",
+    "    mask[descriptor.ds.cellsOnEdge].values, axis=1\n",
+    ")\n",
+    "\n",
+    "cv_edges = descriptor.ds.nEdges[edge_mask]\n",
+    "cv_vertices = descriptor.ds.verticesOnEdge[edge_mask]\n",
+    "\n",
+    "nVertices = cv_vertices.sizes[\"nEdges\"]\n",
+    "\n",
+    "xVertex = ds.xVertex.values\n",
+    "yVertex = ds.yVertex.values\n",
+    "\n",
+    "xv_unsorted = np.insert(xVertex[cv_vertices], 2, np.nan, axis=1)\n",
+    "yv_unsorted = np.insert(yVertex[cv_vertices], 2, np.nan, axis=1)\n",
+    "\n",
+    "vertex_1 = cv_vertices.isel(TWO=0).values\n",
+    "vertex_2 = cv_vertices.isel(TWO=1).values\n",
+    "\n",
+    "graph = nx.Graph()\n",
+    "graph.add_edges_from(zip(vertex_1, vertex_2, strict=False))\n",
+    "cv_euler = np.array(list(nx.eulerian_circuit(graph)))\n",
+    "\n",
+    "xv_sorted = np.insert(xVertex[cv_euler], 2, np.nan, axis=1)\n",
+    "yv_sorted = np.insert(yVertex[cv_euler], 2, np.nan, axis=1)\n",
+    "\n",
+    "lw = 2.5\n",
+    "cmap = cm.plasma\n",
+    "norm = cm.colors.Normalize(vmin=0, vmax=nVertices)\n",
+    "s_map = cm.ScalarMappable(norm=norm, cmap=cmap)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "remove-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "fig, ax = single_pannel()\n",
+    "\n",
+    "pc = mosaic.polypcolor(\n",
+    "    ax, descriptor, mask, cmap=\"binary_r\", alpha=0.5, ec=\"k\", lw=1\n",
+    ")\n",
+    "\n",
+    "_xy = descriptor.cell_patches[0]\n",
+    "elements = [\n",
+    "    mpatches.Polygon(_xy, fc=\"white\", ec=\"k\", label=\"False\"),\n",
+    "    mpatches.Polygon(_xy, fc=\"grey\", ec=\"k\", label=\"True\"),\n",
+    "]\n",
+    "\n",
+    "ax.legend(handles=elements, loc=\"lower left\", fontsize=\"large\", framealpha=1.0)\n",
+    "\n",
+    "ax.set_xlim(-0.25, 0.25)\n",
+    "ax.set_ylim(-0.25, 0.25);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "**Figure 2.** Boolean mask of cells with a value greater than $1$ for the field plotted above (**Figure 1**). Gray cells are above (True) and white cells are below (False) the contour level. \n",
+    "\n",
+    "From examining the boolean mask, plotted on the native mesh, it becomes clear that one way to display contour boundary is to use the edges of the mesh where the mask is true on one side and false on the other.\n",
+    "To identify the edges where this is true, we'll use the \"exculusive or\" (i.e. $\\mathrm{XOR}$) operation along the second dimension of the $\\mathrm{cellsOnEdge}$ array, which is of size $\\mathrm{nEdges} \\times 2$. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "remove-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "fig, ax = single_pannel()\n",
+    "\n",
+    "pc = mosaic.polypcolor(\n",
+    "    ax, descriptor, gauss <= 1.0, cmap=\"binary_r\", alpha=0.5, ec=\"k\", lw=1\n",
+    ")\n",
+    "\n",
+    "ax.plot(\n",
+    "    xv_unsorted.ravel(), yv_unsorted.ravel(), c=\"tab:blue\", lw=lw, label=\"Edge\"\n",
+    ")\n",
+    "\n",
+    "_xy = descriptor.cell_patches[0]\n",
+    "elements = [\n",
+    "    mpatches.Polygon(_xy, fc=\"white\", ec=\"k\", label=\"True\"),\n",
+    "    mpatches.Polygon(_xy, fc=\"grey\", ec=\"k\", label=\"False\"),\n",
+    "]\n",
+    "\n",
+    "legend = ax.legend(loc=\"lower right\", fontsize=\"large\", framealpha=1.0)\n",
+    "\n",
+    "ax.add_artist(legend)\n",
+    "\n",
+    "ax.legend(handles=elements, loc=\"lower left\", fontsize=\"large\", framealpha=1.0)\n",
+    "ax.set_xlim(-0.25, 0.25)\n",
+    "ax.set_ylim(-0.25, 0.25);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "**Figure 3.** Boolean mask of cells with a value greater than $1$, with edges corresponding to the contour boundary denoted in blue. \n",
+    "\n",
+    "Unfortunately it's not quite that simple. While we've identified the edges that correspond to the contour boundary, the **order** of those edges are quite important for plotting."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "remove-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "fig, ax = double_pannel()\n",
+    "\n",
+    "for i in range(2):\n",
+    "    pc = mosaic.polypcolor(\n",
+    "        ax[i],\n",
+    "        descriptor,\n",
+    "        gauss <= 1.0,\n",
+    "        cmap=\"binary_r\",\n",
+    "        alpha=0.5,\n",
+    "        ec=\"k\",\n",
+    "        lw=1,\n",
+    "    )\n",
+    "\n",
+    "    ax[i].set_xlim(-0.25, 0.25)\n",
+    "    ax[i].set_ylim(-0.25, 0.25)\n",
+    "\n",
+    "for i in range(nVertices):\n",
+    "    c = cmap(norm(i))\n",
+    "    ax[0].plot(\n",
+    "        xVertex[cv_vertices[i]].ravel(),\n",
+    "        yVertex[cv_vertices[i]].ravel(),\n",
+    "        c=c,\n",
+    "        lw=lw,\n",
+    "    )\n",
+    "\n",
+    "ax[1].plot(\n",
+    "    xVertex[cv_vertices].ravel(),\n",
+    "    yVertex[cv_vertices].ravel(),\n",
+    "    c=\"tab:blue\",\n",
+    "    lw=lw,\n",
+    "    label=\"Unsorted\",\n",
+    ")\n",
+    "legend = ax[1].legend()\n",
+    "\n",
+    "cmap = cm.plasma\n",
+    "norm = cm.colors.Normalize(vmin=0, vmax=nVertices)\n",
+    "s_map = cm.ScalarMappable(norm=norm, cmap=cmap)\n",
+    "\n",
+    "cax = inset_axes(\n",
+    "    ax[0],\n",
+    "    width=\"50%\",\n",
+    "    height=\"5%\",\n",
+    "    loc=\"lower left\",\n",
+    "    bbox_to_anchor=(0.25, 0.0, 1, 1),\n",
+    "    bbox_transform=ax[0].transAxes,\n",
+    "    borderpad=0,\n",
+    ")\n",
+    "\n",
+    "cbar = fig.colorbar(\n",
+    "    s_map,\n",
+    "    cax=cax,\n",
+    "    label=\"Edge Number\",\n",
+    "    spacing=\"proportional\",\n",
+    "    ticks=range(0, nVertices + 1, 10),\n",
+    "    boundaries=np.linspace(-0.5, 0.5 + nVertices, nVertices + 1),\n",
+    "    drawedges=True,\n",
+    "    ax=ax[0],\n",
+    "    shrink=0.5,\n",
+    "    orientation=\"horizontal\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "**Figure 4.** (Left) Contour boundary edges color coded by their index in the boundary edge list. \n",
+    "(Right) An attempt to plot the boundary edges as polygon. \n",
+    "Because of the near random order of edges around the contour, the resulting polygon is self-intersecting. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "### Unstrucuted Mesh Contours as Graphs\n",
+    "\n",
+    "Using the $\\mathrm{XOR}$ operator and the $\\mathrm{cellsOnEdge}$ connectivity array, we have identified the edges corresponding to the contour boundary.\n",
+    "These contour edges are useful, but for plotting purposed what we are really interested beginning and end points of these edges so that we can plot them as a line. \n",
+    "We can use the $\\mathrm{verticesOnEdge}$ connectivity array ($\\mathrm{nEdges} \\times 2$), for the subset of edges that corresponds to the contour boundary, to get the information we need.\n",
+    "Now this subset of $\\mathrm{verticesOnEdge}$ array can be treated as a graph, where the vertices and edges of the unstrucuted mesh become the vertrices and edges of graph. \n",
+    "\n",
+    "The advantage of treating the contour boundary as a graph, is that we can leverage graph theory algorithms as implemented in [`networkx`](https://networkx.org/documentation/stable/) to efficient traverse and manipulate the contour graphs. \n",
+    "\n",
+    "**Eulerian Circuit**:  \n",
+    "In graph theory a [Eulerian Circuit](https://en.wikipedia.org/wiki/Eulerian_path) is path through a finite graph that visits every edge exactly once, that starts and ends on the same vertex. \n",
+    "The Eulerian Circuit effectively \"sorts\" the graph, which we demonstrated that we need above.\n",
+    "The algrothimic implementation of creating a Eulerian Circuit effectively is linear in time, so it is very efficient.\n",
+    "Let's examine the Eulerian Circuit of the contour boundary graph we plotted above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "remove-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "fig, ax = double_pannel()\n",
+    "\n",
+    "for i in range(2):\n",
+    "    pc = mosaic.polypcolor(\n",
+    "        ax[i],\n",
+    "        descriptor,\n",
+    "        gauss <= 1.0,\n",
+    "        cmap=\"binary_r\",\n",
+    "        alpha=0.5,\n",
+    "        ec=\"k\",\n",
+    "        lw=1,\n",
+    "    )\n",
+    "\n",
+    "    ax[i].set_xlim(-0.25, 0.25)\n",
+    "    ax[i].set_ylim(-0.25, 0.25)\n",
+    "\n",
+    "for i in range(nVertices):\n",
+    "    c = cmap(norm(i))\n",
+    "\n",
+    "    ax[0].plot(\n",
+    "        xVertex[cv_euler[i]].ravel(),\n",
+    "        yVertex[cv_euler[i]].ravel(),\n",
+    "        c=c,\n",
+    "        lw=lw,\n",
+    "        label=\"Edge\",\n",
+    "    )\n",
+    "\n",
+    "ax[1].plot(\n",
+    "    xVertex[cv_euler].ravel(),\n",
+    "    yVertex[cv_euler].ravel(),\n",
+    "    c=\"tab:blue\",\n",
+    "    lw=lw,\n",
+    "    label=\"Euler Circuit (ie. sorted)\",\n",
+    ")\n",
+    "legend = ax[1].legend(framealpha=1.0)\n",
+    "\n",
+    "cax = inset_axes(\n",
+    "    ax[0],\n",
+    "    width=\"50%\",\n",
+    "    height=\"5%\",\n",
+    "    loc=\"lower left\",\n",
+    "    bbox_to_anchor=(0.25, 0.0, 1, 1),\n",
+    "    bbox_transform=ax[0].transAxes,\n",
+    "    borderpad=0,\n",
+    ")\n",
+    "\n",
+    "cbar = fig.colorbar(\n",
+    "    s_map,\n",
+    "    cax=cax,\n",
+    "    label=\"Edge Number\",\n",
+    "    spacing=\"proportional\",\n",
+    "    ticks=range(0, nVertices + 1, 10),\n",
+    "    boundaries=np.linspace(-0.5, 0.5 + nVertices, nVertices + 1),\n",
+    "    drawedges=True,\n",
+    "    ax=ax[0],\n",
+    "    shrink=0.5,\n",
+    "    orientation=\"horizontal\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "**Figure 5.** (Left) Euler circuit of contour boundary edges colorcoded by their index in the boundary edge list. (Right) Euler circuit of contour boundary edges as polygon. Because the Euler circuit is sorted, the resulting polygon is valid (i.e. not-self intersecting). \n",
+    "\n",
+    "With the Eulerian Circuit, we can now plot the contour boundary as polygon. This is the basic functionality we need to plot unstructured contour boundaries in `matplotlib`. \n",
+    "Before we move on, let's quickly look at another way to deliniate the contour boundary. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "### Edge vs. Cell Contouring\n",
+    "\n",
+    "Let's return to the initial boolean mask, but now with a scatter plot added discretely showing the mask values at cell centers. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "remove-input",
+     "hide-cell",
+     "remove-output",
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "fig, ax = single_pannel()\n",
+    "\n",
+    "pc = mosaic.polypcolor(\n",
+    "    ax, descriptor, mask, cmap=\"binary_r\", alpha=0.5, ec=\"k\", lw=1\n",
+    ")\n",
+    "scatter = ax.scatter(\n",
+    "    ds.xCell, ds.yCell, c=mask, cmap=\"binary_r\", s=2.5, ec=\"k\", lw=0.1\n",
+    ")\n",
+    "\n",
+    "kw = {\"fmt\": \"{x!s:}\", \"func\": lambda x: ~x.astype(bool)}\n",
+    "\n",
+    "# produce a legend with the unique colors from the scatter\n",
+    "legend1 = ax.legend(\n",
+    "    *scatter.legend_elements(**kw), loc=\"lower left\", title=\"Classes\"\n",
+    ")\n",
+    "ax.add_artist(legend1)\n",
+    "\n",
+    "ax.set_xlim(-0.25, 0.25)\n",
+    "ax.set_ylim(-0.25, 0.25);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "20",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "hide-cell",
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "**Figure 6.** Boolean mask of cells with a value greater than $1$, with mask values also discretly plotted at cell centers.\n",
+    "\n",
+    "After some close examination, one might notice *another* way to draw contour boundary: connecting the cell centers of boundary cells where the condition is true. We will refer to this type of contour boundary as a \"cell contour\". Unfortunately, the connectivity logic here is not quite a simple as \"edge contour\". "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "21",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "(cell_idxs,) = np.where(~mask)\n",
+    "\n",
+    "# initial edge mask, will also return all edge within the contour\n",
+    "# not just those along the perimiter\n",
+    "edge_mask = np.logical_and.reduce(\n",
+    "    np.isin(descriptor.ds.cellsOnEdge, cell_idxs), axis=1\n",
+    ")\n",
+    "# initial edges\n",
+    "cc_edges = descriptor.ds.nEdges[edge_mask]\n",
+    "\n",
+    "c_edge_union = np.union1d(cv_edges, cc_edges)\n",
+    "c_unique_vetices = np.unique(cv_vertices)\n",
+    "\n",
+    "c_edge_on_vertices = descriptor.ds.edgesOnVertex[c_unique_vetices]\n",
+    "\n",
+    "vertex_mask = np.logical_and.reduce(\n",
+    "    np.isin(c_edge_on_vertices, c_edge_union), axis=1\n",
+    ")\n",
+    "\n",
+    "# update edge mask\n",
+    "egde_mask = np.isin(c_edge_on_vertices.values[vertex_mask], cc_edges)\n",
+    "\n",
+    "edge_idx = c_edge_on_vertices.values[vertex_mask][egde_mask]\n",
+    "cc_cells = descriptor.ds.cellsOnEdge[edge_idx]\n",
+    "\n",
+    "nCells = cc_cells.shape[0]\n",
+    "\n",
+    "xc_unsorted = np.insert(ds.xCell[cc_cells].values, 2, np.nan, axis=1)\n",
+    "yc_unsorted = np.insert(ds.yCell[cc_cells].values, 2, np.nan, axis=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "22",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "remove-input",
+     "hide-cell",
+     "remove-output",
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "fig, ax = single_pannel()\n",
+    "\n",
+    "pc = mosaic.polypcolor(\n",
+    "    ax, descriptor, mask, cmap=\"binary_r\", alpha=0.5, ec=\"k\", lw=1\n",
+    ")\n",
+    "\n",
+    "scatter = ax.scatter(\n",
+    "    ds.xCell, ds.yCell, c=mask, cmap=\"binary_r\", s=2.5, ec=\"k\", lw=0.1\n",
+    ")\n",
+    "\n",
+    "ax.plot(\n",
+    "    xc_unsorted.ravel(),\n",
+    "    yc_unsorted.ravel(),\n",
+    "    c=\"tab:orange\",\n",
+    "    lw=lw,\n",
+    "    label=\"Cell\",\n",
+    ")\n",
+    "\n",
+    "legend = ax.legend(loc=\"lower right\")\n",
+    "\n",
+    "ax.add_artist(legend)\n",
+    "\n",
+    "kw = {\"fmt\": \"{x!s:}\", \"func\": lambda x: ~x.astype(bool)}\n",
+    "legend1 = ax.legend(\n",
+    "    *scatter.legend_elements(**kw), loc=\"lower left\", title=\"Classes\"\n",
+    ")\n",
+    "ax.add_artist(legend1)\n",
+    "\n",
+    "ax.set_xlim(-0.25, 0.25)\n",
+    "ax.set_ylim(-0.25, 0.25);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "23",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "hide-cell",
+     "remove-cell"
+    ]
+   },
+   "source": [
+    "**Figure 7.** Boolean mask plotted on cells and  discretly plotted at cell centers. Contour boundary created by connecting cell centers of the boundary cells is show in orange. \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "## Interface\n",
+    "\n",
+    "With a basic sketch of the algorithmic approach outlined above, let's now discuss how we will implement this in practice and how we envision a user interacting with it. \n",
+    "The goal is to provide contouring ability in `mosaic` where the interface to our contouring functions are as close as possible to `matplotlib` interface. Such that users can capitialize on their previous experience with `matplotlib` and seamlessly contour *directly* on the unstructed mesh. \n",
+    "\n",
+    "Ideally, we will implement something like: \n",
+    "```python \n",
+    "mosaic.contour(ax, descriptor, field, ...)\n",
+    "mosaic.contourf(ax, descriptor, field, ...)\n",
+    "```\n",
+    "where `...` are the **exact** same keyword positional and key-word arguments as the `matplotlib` comensurate functions. \n",
+    "\n",
+    "**To Do**:\n",
+    "- Explain the `matplotlib.contour.ContourSet` object and how we plan to subclass for seamless integration. \n",
+    "\n",
+    "- Explain `countrpy.CountrGenerator`, the various line and fill type, and how they integrate with `matplotlib` (through Path objects). \n",
+    "\n",
+    "  - https://contourpy.readthedocs.io/en/v1.3.3/user_guide/calculate/fill_type.html#fill-type\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "25",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "## Unfilled Contours\n",
+    "\n",
+    "We'll begin with unfilled contours (i.e. `mosaic.contour`), as they are simpler task. \n",
+    "\n",
+    "Instead of such a simple gaussian field as we consider before, let's work with something more complicated:\n",
+    "$$\n",
+    "f(x, y) = A \\sin \\left(\\frac{N \\pi x}{L_{\\rm x}}\\right) \\cos \\left(\\frac{N \\pi y}{L_{\\rm y}}\\right)\n",
+    "$$\n",
+    "where:\n",
+    "  - $A$ is the amplitude\n",
+    "  - $N$ is the period\n",
+    "  - $L_{\\rm x}$ and $L_{\\rm y}$ as the domain lengths in the $x$ and $y$ directions, respectively\n",
+    "\n",
+    "We'll also slightly increase the size of the mesh to be $50 \\times 50$ cells."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "ds = planar_hex_mesh(100)\n",
+    "\n",
+    "field = sinusoid(ds.xCell, ds.yCell)\n",
+    "descriptor = mosaic.Descriptor(ds)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "def regular_coord(ds, N=100):\n",
+    "    return np.linspace(float(ds.min()), float(ds.max()), N)\n",
+    "\n",
+    "\n",
+    "N = int(ds.sizes[\"nCells\"] ** 0.5)\n",
+    "reg_x = regular_coord(ds.xCell, N=N)\n",
+    "reg_y = regular_coord(ds.yCell, N=N)\n",
+    "\n",
+    "rect_grid = np.meshgrid(reg_x, reg_y)\n",
+    "rect_data = sinusoid(*rect_grid)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "remove-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "fig, ax = single_pannel()\n",
+    "\n",
+    "pc = mosaic.polypcolor(ax, descriptor, field, vmax=2.0, vmin=-2.0, aa=False)\n",
+    "fig.colorbar(pc, shrink=0.5, extend=\"both\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "**Figure 6.** Checkerboard field, evaluated on a $100 \\times 100$ cell mesh.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "30",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "A first step, let's create the boolean "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "31",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "mask = field < 0.0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "remove-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "fig, ax = double_pannel()\n",
+    "\n",
+    "pc = mosaic.polypcolor(\n",
+    "    ax[0], descriptor, mask, cmap=\"binary\", alpha=1 / 3, ec=\"k\", lw=1 / 5\n",
+    ")\n",
+    "\n",
+    "ax[1].contour(*rect_grid, rect_data, levels=[0.0], colors=\"tab:blue\")\n",
+    "ax[1].contourf(\n",
+    "    *rect_grid, rect_data, levels=[-2.0, 0.0], colors=\"k\", alpha=1 / 3\n",
+    ");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "33",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "**Figure 7.** (Left) Boolean mask of $f(x, y) < 0.0$ evaluated on the MPAS mesh. (Right) The same checkerboard field, evaluated and contoured on a regular quadrilateral mesh. Blue lines are the contour lines and grey is the filled contour area. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "**Boundaries**\n",
+    "\n",
+    "We can see from the `matplotlib.pyplot.contour` example above (RHS of Figure 7), that contour lines should be discontinuous when they intersect with a boundary. For example, while the plotted mask flows plot boundary, the contour lines abruptly end. They do not from closed loops by using the boundary. We'll mimic this behavior in `mosaic`. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "35",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "fig, ax = double_pannel()\n",
+    "\n",
+    "kwargs = {\n",
+    "    \"levels\": [-1.0, 0.0, 1.0],\n",
+    "    \"colors\": [\"tab:blue\", \"tab:orange\", \"tab:red\"],\n",
+    "    \"linestyles\": \"-\",\n",
+    "}\n",
+    "\n",
+    "mosaic.polypcolor(ax[0], descriptor, field, alpha=1 / 3, ec=\"k\", lw=1 / 5)\n",
+    "mosaic.contour(\n",
+    "    ax[0],\n",
+    "    descriptor,\n",
+    "    field,\n",
+    "    alpha=1.0,\n",
+    "    **kwargs,\n",
+    ")\n",
+    "\n",
+    "ax[1].pcolormesh(*rect_grid, rect_data, alpha=1 / 3, lw=1 / 5)\n",
+    "ax[1].contour(*rect_grid, rect_data, **kwargs)\n",
+    "\n",
+    "ax[0].set_title(r\"\\texttt{mosiac.contour}\")\n",
+    "ax[1].set_title(r\"\\texttt{plt.contour}\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "36",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "**Figure 8**. (Left) `mosaic.contour` result for contours at $-1, 0, 1$ (blue, orange, red) of the checkerboard field, evaluated on the MPAS mesh. (Right) `plt.contour` of the same checkerboard field on a regular quadrilateral grid for comparison. \n",
+    "\n",
+    "As we can see above, we get good agreement between our `mosaic.contour` implementation and the `plt.contour` result. The major difference is the jagged appearance of the MPAS contours due to the coarse resolution of the mesh, **but** this is desired feature of implementation. `plt.contour` does linear interpolation, which produces the smooth boundaries, but that is not something we want (or at least on all the time). Future work will investigate adding optional support for smooth contours. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "37",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "## Filled Contours\n",
+    "\n",
+    "Filled contours, specifically the possibility of interior boundaries, presents a challenge to our treatment so far mesh contours as graphs.\n",
+    "To illustrate this challenge we will visualize two, multi-component, [isomorphic](https://en.wikipedia.org/wiki/Graph_isomorphism) graphs, which according to graph theory are equivalent graphs. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "38",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "remove-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# --------- Build a graph: two disconnected 8-cycles ---------\n",
+    "n = 8\n",
+    "G = nx.disjoint_union(\n",
+    "    nx.cycle_graph(n), nx.cycle_graph(n)\n",
+    ")  # nodes 0..7 and 8..15\n",
+    "\n",
+    "\n",
+    "# Helper: place nodes evenly on a circle\n",
+    "def circle_pos(nodes, center=(0.0, 0.0), radius=1.0, phase=0.0):\n",
+    "    cx, cy = center\n",
+    "    pos = {}\n",
+    "    for i, node in enumerate(nodes):\n",
+    "        theta = phase + 2.0 * np.pi * i / len(nodes)\n",
+    "        pos[node] = (cx + radius * np.cos(theta), cy + radius * np.sin(theta))\n",
+    "    return pos\n",
+    "\n",
+    "\n",
+    "outer_nodes = list(range(8))\n",
+    "inner_nodes = list(range(8, 16))\n",
+    "\n",
+    "# --------- Embedding 1: Nested rings ---------\n",
+    "pos_nested = {}\n",
+    "pos_nested.update(\n",
+    "    circle_pos(outer_nodes, center=(+1, 0), radius=1.5, phase=0.0)\n",
+    ")\n",
+    "pos_nested.update(\n",
+    "    circle_pos(inner_nodes, center=(+1, 0), radius=0.75, phase=0.2)\n",
+    ")\n",
+    "\n",
+    "# --------- Embedding 2: Separate rings (no containment) ---------\n",
+    "pos_separate = {}\n",
+    "pos_separate.update(\n",
+    "    circle_pos(outer_nodes, center=(0, 0), radius=1.5, phase=0.0)\n",
+    ")\n",
+    "pos_separate.update(\n",
+    "    circle_pos(inner_nodes, center=(+3, 0), radius=0.75, phase=0.2)\n",
+    ")\n",
+    "\n",
+    "\n",
+    "# --------- Visualization: same graph, different coordinates ---------\n",
+    "def draw_embedding(ax, pos, title):\n",
+    "    # Color by component membership\n",
+    "    node_colors = []\n",
+    "    for v in G.nodes():\n",
+    "        node_colors.append(\"tab:blue\" if v in outer_nodes else \"tab:orange\")\n",
+    "\n",
+    "    nx.draw(\n",
+    "        G,\n",
+    "        pos=pos,\n",
+    "        ax=ax,\n",
+    "        with_labels=True,\n",
+    "        node_color=node_colors,\n",
+    "        edge_color=\"gray\",\n",
+    "        node_size=150,\n",
+    "        font_size=8,\n",
+    "        width=2,\n",
+    "    )\n",
+    "    ax.set_title(title)\n",
+    "    ax.set_aspect(\"equal\")\n",
+    "    # ax.axis(\"off\")\n",
+    "\n",
+    "\n",
+    "fig, ax = double_pannel()\n",
+    "draw_embedding(ax[0], pos_nested, \"nested geometry\")\n",
+    "draw_embedding(ax[1], pos_separate, \"separated geometry\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "39",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "**Figure 9**. Two multi-componnet isomorphic graphs, plotted using their coordinate information.\n",
+    "\n",
+    "As far a graph theory is concerned, the two graphs above are equivalent.\n",
+    "Because the coordinate information to plot these graphs, we can see an important distinction: the graph on the left is nested where the graph on the right is separated. \n",
+    "\n",
+    "For filled contours, **Figure 9.** is a crude, but illustrative, example of a contour with an interior boundary.\n",
+    "So far we only used the mesh connectivity information to create the unfilled contour boundaries, where coordinate information has only been used to plotting.\n",
+    "**But**, for filled contours after creating the contour boundaries from the connectivity information, we'll need to use coordinate info to recursive search of interior boundaries within the resulting contours.\n",
+    "\n",
+    "We can efficiently recursively search for interior boundaries using [`shapely.STRtree`](https://shapely.readthedocs.io/en/stable/strtree.html#shapely.STRtree), which uses the bounding boxes of each geometry to query for containment. \n",
+    "\n",
+    "\n",
+    "### Relative Ordering\n",
+    "\n",
+    "One final `matplotlib` consideration, is the relative ordering (ie., clockwise vs counter-clockwise) of interior boundaries relative to their exterior boundaries. \n",
+    "\n",
+    "In order for an interior boundary to be unfilled, as intended, it's relative order must be opposite the relative order of the exterior boundary.\n",
+    "For more information about this, refer to the `matplotlib` documentation: [here](https://matplotlib.org/stable/gallery/shapes_and_collections/donut.html#sphx-glr-gallery-shapes-and-collections-donut-py). \n",
+    "\n",
+    "Following the `matplotlib` documentation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "remove-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "def wise(v):\n",
+    "    if v == 1:\n",
+    "        return \"CCW\"\n",
+    "    return \"CW\"\n",
+    "\n",
+    "\n",
+    "def make_circle(r):\n",
+    "    t = np.arange(0, np.pi * 2.0, 0.01)\n",
+    "    t = t.reshape((len(t), 1))\n",
+    "    x = r * np.cos(t)\n",
+    "    y = r * np.sin(t)\n",
+    "    return np.hstack((x, y))\n",
+    "\n",
+    "\n",
+    "Path = mpath.Path\n",
+    "\n",
+    "fig, ax = single_pannel((5.5, 5.5))\n",
+    "# fig, ax = plt.subplots(layout='constrained')\n",
+    "\n",
+    "inside_vertices = make_circle(0.5)\n",
+    "outside_vertices = make_circle(1.0)\n",
+    "codes = (\n",
+    "    np.ones(len(inside_vertices), dtype=mpath.Path.code_type)\n",
+    "    * mpath.Path.LINETO\n",
+    ")\n",
+    "codes[0] = mpath.Path.MOVETO\n",
+    "\n",
+    "for i, (inside, outside) in enumerate(((1, 1), (1, -1), (-1, 1), (-1, -1))):\n",
+    "    # Concatenate the inside and outside subpaths together, changing their\n",
+    "    # order as needed\n",
+    "    vertices = np.concatenate(\n",
+    "        (outside_vertices[::outside], inside_vertices[::inside])\n",
+    "    )\n",
+    "    # Shift the path\n",
+    "    vertices[:, 0] += i * 2.5\n",
+    "    # The codes will be all \"LINETO\" commands, except for \"MOVETO\"s at the\n",
+    "    # beginning of each subpath\n",
+    "    all_codes = np.concatenate((codes, codes))\n",
+    "    # Create the Path object\n",
+    "    path = mpath.Path(vertices, all_codes)\n",
+    "    # Add plot it\n",
+    "    patch = mpatches.PathPatch(path, facecolor=\"#885500\", edgecolor=\"black\")\n",
+    "    ax.add_patch(patch)\n",
+    "\n",
+    "    ax.annotate(\n",
+    "        f\"Outside {wise(outside)},\\nInside {wise(inside)}\",\n",
+    "        (i * 2.5, -1.5),\n",
+    "        va=\"top\",\n",
+    "        ha=\"center\",\n",
+    "    )\n",
+    "\n",
+    "ax.set_xlim(-2, 10)\n",
+    "ax.set_ylim(-3, 2);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "41",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "**Figure 10**. Illustration of the importance of the interior vs. exterior relative ordering for rendering interior boundaries. \n",
+    "\n",
+    "\n",
+    "So, with above considerations in mind let's return to the same sine field, evaluated on a $100 \\times 100$ cell mesh.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "42",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "remove-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "fig, ax = single_pannel()\n",
+    "\n",
+    "pc = mosaic.polypcolor(ax, descriptor, field, vmax=2.0, vmin=-2.0, aa=False)\n",
+    "\n",
+    "fig.colorbar(pc, shrink=0.5, extend=\"both\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "43",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "**Figure 11.** Checkerboard field, evaluated on a $100 \\times 100$ cell mesh.\n",
+    "\n",
+    "Like filled contouring, our first step will be to create the boolean mask.\n",
+    "Because this is a filled contour we will need both an upper and lower bound (cf., unfilled). "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "44",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "cell_mask = (field > -1.0) & (field < 0.0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "45",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "remove-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "fig, ax = double_pannel()\n",
+    "\n",
+    "mosaic.contour(\n",
+    "    ax[0],\n",
+    "    descriptor,\n",
+    "    field,\n",
+    "    levels=[-1.0, 0.0],\n",
+    "    colors=\"tab:blue\",\n",
+    "    linestyles=\"-\",\n",
+    ")\n",
+    "mosaic.polypcolor(\n",
+    "    ax[0],\n",
+    "    descriptor,\n",
+    "    cell_mask,\n",
+    "    cmap=\"binary\",\n",
+    "    alpha=1 / 3,  # ec='k', lw=1/5\n",
+    ")\n",
+    "\n",
+    "ax[1].contour(\n",
+    "    *rect_grid,\n",
+    "    rect_data,\n",
+    "    levels=[-1.0, 0.0],\n",
+    "    colors=\"tab:blue\",\n",
+    "    linestyles=\"-\",\n",
+    ")\n",
+    "ax[1].contourf(\n",
+    "    *rect_grid, rect_data, levels=[-1.0, 0.0], colors=\"k\", alpha=1 / 3\n",
+    ");\n",
+    "# fig.savefig(\"figs/test.pdf\", bbox_inches='tight')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "46",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "**Figure 12.** (Left) Boolean mask of $-1.0 < f(x, y) < 0.0$ evaluated on the MPAS mesh. (Right) The same checkerboard field, evaluated and contoured on a regular quadrilateral mesh. The grey is the filled contour area. \n",
+    "\n",
+    "As a first step, we will use the exact same steps as unfilled contours to extract and sort the contour boundaries using the connectivity information.\n",
+    "One important difference between the filled (grey) and unfilled (blue lines) is that the filled contours follow the mesh boundary."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "47",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "mpas_contour_generator = MPASContourGenerator(descriptor, field)\n",
+    "graph = mpas_contour_generator._create_contour_graph(cell_mask, filled=True)\n",
+    "polys = mpas_contour_generator._split_and_order_graph(graph)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "48",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "remove-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "fig, ax = single_pannel()\n",
+    "\n",
+    "for p in polys:\n",
+    "    ax.scatter(*p.T, s=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "49",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "**Figure 13.** The contour boundaries identified just using connectivity information.\n",
+    "Each unique contour component has it's own color.\n",
+    "Notice the pink and brown boundaries are really interior boundaries of the blue contour, but just using connectivity information alone is not enough to identify this. \n",
+    "\n",
+    "We will now used the coordinate information to recursively search for containment of our contour components.\n",
+    "If we find an interior boundary during this recursive search, we will also ensure it's relative order is opposite it's parent to ensure proper plotting in `matplotlib` once we will the contours. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "50",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "polys = mpas_contour_generator._split_and_order_graph(graph)\n",
+    "codes = mpas_contour_generator._assemble_contour_codes(polys)\n",
+    "\n",
+    "polys, codes = mpas_contour_generator._sort_filled_contours(polys, codes)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "51",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "remove-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "fig, ax = single_pannel()\n",
+    "\n",
+    "for _poly in polys:\n",
+    "    ax.scatter(*_poly.T, s=1.0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "52",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "**Figure 14.** The contour boundaries identified after recursively search for containment using the coordinate information.\n",
+    "Notice the interior boundaries of the blue contour are now blue as we'd expect. \n",
+    "\n",
+    "With all this in hand, we now have a fully functional filled contour algorthinm. \n",
+    "Now let's see it in practice and compare to our `matplotlib` regularly spaced reference. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "fig, ax = double_pannel()\n",
+    "\n",
+    "kwargs = {\n",
+    "    \"levels\": [-1.0, 0.0, 1.0],\n",
+    "    \"colors\": [\"tab:blue\", \"tab:orange\"],\n",
+    "    \"linestyles\": \"-\",\n",
+    "}\n",
+    "\n",
+    "mosaic.polypcolor(ax[0], descriptor, field, alpha=1 / 3, ec=\"k\", lw=1 / 5)\n",
+    "mosaic.contourf(\n",
+    "    ax[0],\n",
+    "    descriptor,\n",
+    "    field,\n",
+    "    **kwargs,\n",
+    ")\n",
+    "\n",
+    "ax[1].pcolormesh(*rect_grid, rect_data, alpha=1 / 3, lw=1 / 5)\n",
+    "ax[1].contourf(*rect_grid, rect_data, **kwargs)\n",
+    "\n",
+    "ax[0].set_title(r\"\\texttt{mosiac.contour}\")\n",
+    "ax[1].set_title(r\"\\texttt{plt.contour}\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "54",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "**Figure 15.** `mosaic.contourf` result for filled contour levels of $-1, 0, 1$ of the checkerboard field, evaluated on the MPAS mesh. (Right) `plt.contourf` of the same checkerboard field on a regular quadrilateral grid for comparison. \n",
+    "\n",
+    "As we can see above, we also get good agreement between our `mosaic.contourf` implementation and the `plt.contourf` result.\n",
+    "Again, the major difference is the jagged appearance of the MPAS contours due to the coarse resolution of the mesh, **but** this is desired feature of implementation. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "## Future Work\n",
+    "\n",
+    "### Smooth (interpolated) contours:\n",
+    "  - https://www.boristhebrave.com/2018/04/15/marching-cubes-tutorial/\n",
+    "  - https://www.cs.wustl.edu/~taoju/cse554/lectures/lect04_Contouring_I.pdf\n",
+    "  - https://www.cse.wustl.edu/~taoju/research/dualContour.pdf\n",
+    "  - https://en.wikipedia.org/wiki/Marching_squares\n",
+    "\n",
+    "### Marching Squares implementation: \n",
+    "  - `skimage` has a `cython` based marching squares implementation that we could probably easily port to marching triangles.\n",
+    "  - https://github.com/scikit-image/scikit-image/blob/main/src/skimage/measure/_find_contours_cy.pyx"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.9"
+  },
+  "mystnb": {
+   "output_align": "center"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/developers_guide/design_docs/contouring.ipynb
+++ b/docs/developers_guide/design_docs/contouring.ipynb
@@ -20,11 +20,11 @@
     "\n",
     "import io\n",
     "from contextlib import redirect_stdout\n",
+    "from itertools import pairwise\n",
     "\n",
     "import matplotlib.patches as mpatches\n",
     "import matplotlib.path as mpath\n",
     "import matplotlib.pyplot as plt\n",
-    "import networkx as nx\n",
     "import numpy as np\n",
     "from matplotlib import cm\n",
     "from mpas_tools.mesh.conversion import convert, cull\n",
@@ -33,7 +33,7 @@
     "from mpl_toolkits.axes_grid1.inset_locator import inset_axes\n",
     "\n",
     "import mosaic\n",
-    "from mosaic.contour import MPASContourGenerator\n",
+    "from mosaic.contour import ContourGraph, MPASContourGenerator\n",
     "\n",
     "plt.rcParams[\"text.usetex\"] = True\n",
     "\n",
@@ -137,7 +137,7 @@
    "source": [
     "# Contouring\n",
     "\n",
-    "**Developer**: Andrew Nolan (github:[`andrewdnolan`](https://github.com/andrewdnolan/))\n",
+    "**Developer**: Andrew Nolan ([`@andrewdnolan`](https://github.com/andrewdnolan/))\n",
     "\n",
     "## Overview\n",
     "For complete visualization capabilities in `mosaic`, we need to be able to create contour and filled contour plots. Unfortunately, we are unable to use the existing [`matplotlib.pyplot.contour`](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.contour.html) and [`matplotlib.pyplot.contourf`](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.contourf.html) functions, due to two `matplotlib` requirements: \n",
@@ -270,12 +270,9 @@
     "vertex_1 = cv_vertices.isel(TWO=0).values\n",
     "vertex_2 = cv_vertices.isel(TWO=1).values\n",
     "\n",
-    "graph = nx.Graph()\n",
-    "graph.add_edges_from(zip(vertex_1, vertex_2, strict=False))\n",
-    "cv_euler = np.array(list(nx.eulerian_circuit(graph)))\n",
-    "\n",
-    "xv_sorted = np.insert(xVertex[cv_euler], 2, np.nan, axis=1)\n",
-    "yv_sorted = np.insert(yVertex[cv_euler], 2, np.nan, axis=1)\n",
+    "graph = ContourGraph(vertex_1, vertex_2)\n",
+    "ordered_vertices = graph.walk(next(iter(graph)))\n",
+    "ordered_vertices.append(ordered_vertices[0])\n",
     "\n",
     "lw = 2.5\n",
     "cmap = cm.plasma\n",
@@ -463,7 +460,7 @@
     "    ax=ax[0],\n",
     "    shrink=0.5,\n",
     "    orientation=\"horizontal\",\n",
-    ")"
+    ");"
    ]
   },
   {
@@ -496,17 +493,18 @@
     "### Unstrucuted Mesh Contours as Graphs\n",
     "\n",
     "Using the $\\mathrm{XOR}$ operator and the $\\mathrm{cellsOnEdge}$ connectivity array, we have identified the edges corresponding to the contour boundary.\n",
-    "These contour edges are useful, but for plotting purposed what we are really interested beginning and end points of these edges so that we can plot them as a line. \n",
-    "We can use the $\\mathrm{verticesOnEdge}$ connectivity array ($\\mathrm{nEdges} \\times 2$), for the subset of edges that corresponds to the contour boundary, to get the information we need.\n",
-    "Now this subset of $\\mathrm{verticesOnEdge}$ array can be treated as a graph, where the vertices and edges of the unstrucuted mesh become the vertrices and edges of graph. \n",
+    "These contour edges are useful, but for plotting purposes what we are really interested in is an ordered sequence of vertices so that we can draw them as a continuous line.\n",
+    "We can use the $\\mathrm{verticesOnEdge}$ connectivity array ($\\mathrm{nEdges} \\times 2$) for the subset of edges that correspond to the contour boundary to get the information we need.\n",
+    "This subset of $\\mathrm{verticesOnEdge}$ naturally defines a graph, where mesh vertices become graph nodes and contour edges become graph edges.\n",
     "\n",
-    "The advantage of treating the contour boundary as a graph, is that we can leverage graph theory algorithms as implemented in [`networkx`](https://networkx.org/documentation/stable/) to efficient traverse and manipulate the contour graphs. \n",
+    "The key structural property of this graph is that every node has **degree at most 2**; each contour vertex is shared by at most two contour edges (the one \"entering\" and the one \"leaving\"). This constraint means every connected component is one of exactly two topologies:\n",
     "\n",
-    "**Eulerian Circuit**:  \n",
-    "In graph theory a [Eulerian Circuit](https://en.wikipedia.org/wiki/Eulerian_path) is path through a finite graph that visits every edge exactly once, that starts and ends on the same vertex. \n",
-    "The Eulerian Circuit effectively \"sorts\" the graph, which we demonstrated that we need above.\n",
-    "The algrothimic implementation of creating a Eulerian Circuit effectively is linear in time, so it is very efficient.\n",
-    "Let's examine the Eulerian Circuit of the contour boundary graph we plotted above."
+    "- **Path graph**:  an open arc whose two degree-1 endpoints lie on the domain boundary. The contour crosses the mesh boundary.\n",
+    "- **Cycle graph**: a closed loop entirely within the domain interior where every node has degree exactly 2.\n",
+    "\n",
+    "Because the maximum degree is 2, traversal reduces to a simple linear chain walk: at each step there is at most one unvisited neighbor. For a **path**, we start at one of the two degree-1 endpoints and walk to the other. For a **cycle**, we start at any node and walk until no unvisited neighbors remain, then close the loop by appending the start node.\n",
+    "\n",
+    "This is implemented in the custom `ContourGraph` class in `mosaic/contour.py`. The `walk()` method performs the chain traversal, and `components()` uses an iterative depth-first search to enumerate connected components. No general graph library is required at runtime — NetworkX is available only as an optional testing utility via `ContourGraph.to_networkx()`."
    ]
   },
   {
@@ -540,23 +538,24 @@
     "    ax[i].set_xlim(-0.25, 0.25)\n",
     "    ax[i].set_ylim(-0.25, 0.25)\n",
     "\n",
-    "for i in range(nVertices):\n",
+    "for i, (j, k) in enumerate(pairwise(ordered_vertices)):\n",
     "    c = cmap(norm(i))\n",
     "\n",
     "    ax[0].plot(\n",
-    "        xVertex[cv_euler[i]].ravel(),\n",
-    "        yVertex[cv_euler[i]].ravel(),\n",
+    "        xVertex[[j, k]],\n",
+    "        yVertex[[j, k]],\n",
     "        c=c,\n",
     "        lw=lw,\n",
     "        label=\"Edge\",\n",
+    "        zorder=10,\n",
     "    )\n",
     "\n",
     "ax[1].plot(\n",
-    "    xVertex[cv_euler].ravel(),\n",
-    "    yVertex[cv_euler].ravel(),\n",
+    "    xVertex[ordered_vertices].ravel(),\n",
+    "    yVertex[ordered_vertices].ravel(),\n",
     "    c=\"tab:blue\",\n",
     "    lw=lw,\n",
-    "    label=\"Euler Circuit (ie. sorted)\",\n",
+    "    label=\"Ordered Cycle Graph\",\n",
     ")\n",
     "legend = ax[1].legend(framealpha=1.0)\n",
     "\n",
@@ -581,7 +580,7 @@
     "    ax=ax[0],\n",
     "    shrink=0.5,\n",
     "    orientation=\"horizontal\",\n",
-    ")"
+    ");"
    ]
   },
   {
@@ -595,10 +594,10 @@
     "tags": []
    },
    "source": [
-    "**Figure 5.** (Left) Euler circuit of contour boundary edges colorcoded by their index in the boundary edge list. (Right) Euler circuit of contour boundary edges as polygon. Because the Euler circuit is sorted, the resulting polygon is valid (i.e. not-self intersecting). \n",
+    "**Figure 5.** (Left) Ordered contour boundary edges color-coded by their index in the boundary edge list. (Right) Ordered contour boundary edges as a polygon. Because the graph traversal produces a sorted vertex sequence, the resulting polygon is valid (i.e. not self-intersecting).\n",
     "\n",
-    "With the Eulerian Circuit, we can now plot the contour boundary as polygon. This is the basic functionality we need to plot unstructured contour boundaries in `matplotlib`. \n",
-    "Before we move on, let's quickly look at another way to deliniate the contour boundary. "
+    "With the ordered vertex sequence from the graph traversal, we can now plot the contour boundary as a polygon. This is the basic functionality we need to plot unstructured contour boundaries in `matplotlib`. \n",
+    "Before we move on, let's quickly look at another way to delineate the contour boundary."
    ]
   },
   {
@@ -811,15 +810,7 @@
     "mosaic.contour(ax, descriptor, field, ...)\n",
     "mosaic.contourf(ax, descriptor, field, ...)\n",
     "```\n",
-    "where `...` are the **exact** same keyword positional and key-word arguments as the `matplotlib` comensurate functions. \n",
-    "\n",
-    "**To Do**:\n",
-    "- Explain the `matplotlib.contour.ContourSet` object and how we plan to subclass for seamless integration. \n",
-    "\n",
-    "- Explain `countrpy.CountrGenerator`, the various line and fill type, and how they integrate with `matplotlib` (through Path objects). \n",
-    "\n",
-    "  - https://contourpy.readthedocs.io/en/v1.3.3/user_guide/calculate/fill_type.html#fill-type\n",
-    "\n"
+    "where `...` are the **exact** same keyword positional and key-word arguments as the `matplotlib` comensurate functions. "
    ]
   },
   {
@@ -1014,7 +1005,7 @@
    "source": [
     "**Boundaries**\n",
     "\n",
-    "We can see from the `matplotlib.pyplot.contour` example above (RHS of Figure 7), that contour lines should be discontinuous when they intersect with a boundary. For example, while the plotted mask flows plot boundary, the contour lines abruptly end. They do not from closed loops by using the boundary. We'll mimic this behavior in `mosaic`. "
+    "We can see from the `matplotlib.pyplot.contour` example above (RHS of Figure 7), that contour lines should be discontinuous when they intersect with a boundary. For example, while the plotted mask follows the plot boundary, the contour lines abruptly end. They do not from closed loops by using the boundary. We'll mimic this behavior in `mosaic`. "
    ]
   },
   {
@@ -1086,7 +1077,7 @@
     "## Filled Contours\n",
     "\n",
     "Filled contours, specifically the possibility of interior boundaries, presents a challenge to our treatment so far mesh contours as graphs.\n",
-    "To illustrate this challenge we will visualize two, multi-component, [isomorphic](https://en.wikipedia.org/wiki/Graph_isomorphism) graphs, which according to graph theory are equivalent graphs. "
+    "To illustrate this challenge we will visualize two, multi-component, [isomorphic](https://en.wikipedia.org/wiki/Graph_isomorphism) graphs, which according to graph theory are equivalent. "
    ]
   },
   {
@@ -1106,9 +1097,16 @@
    "source": [
     "# --------- Build a graph: two disconnected 8-cycles ---------\n",
     "n = 8\n",
-    "G = nx.disjoint_union(\n",
-    "    nx.cycle_graph(n), nx.cycle_graph(n)\n",
-    ")  # nodes 0..7 and 8..15\n",
+    "outer_nodes = list(range(n))\n",
+    "inner_nodes = list(range(n, 2 * n))\n",
+    "\n",
+    "v1 = np.array(list(range(n)) + [n + i for i in range(n)])\n",
+    "v2 = np.array(\n",
+    "    [(i + 1) % n for i in range(n)] + [n + (i + 1) % n for i in range(n)]\n",
+    ")\n",
+    "G = ContourGraph(v1, v2)\n",
+    "\n",
+    "outer_set = set(outer_nodes)\n",
     "\n",
     "\n",
     "# Helper: place nodes evenly on a circle\n",
@@ -1120,9 +1118,6 @@
     "        pos[node] = (cx + radius * np.cos(theta), cy + radius * np.sin(theta))\n",
     "    return pos\n",
     "\n",
-    "\n",
-    "outer_nodes = list(range(8))\n",
-    "inner_nodes = list(range(8, 16))\n",
     "\n",
     "# --------- Embedding 1: Nested rings ---------\n",
     "pos_nested = {}\n",
@@ -1145,25 +1140,25 @@
     "\n",
     "# --------- Visualization: same graph, different coordinates ---------\n",
     "def draw_embedding(ax, pos, title):\n",
-    "    # Color by component membership\n",
-    "    node_colors = []\n",
-    "    for v in G.nodes():\n",
-    "        node_colors.append(\"tab:blue\" if v in outer_nodes else \"tab:orange\")\n",
+    "    # Draw edges\n",
+    "    for u, neighbors in G._adj.items():\n",
+    "        for v in neighbors:\n",
+    "            if u < v:\n",
+    "                x0, y0 = pos[u]\n",
+    "                x1, y1 = pos[v]\n",
+    "                ax.plot([x0, x1], [y0, y1], color=\"gray\", lw=2, zorder=1)\n",
     "\n",
-    "    nx.draw(\n",
-    "        G,\n",
-    "        pos=pos,\n",
-    "        ax=ax,\n",
-    "        with_labels=True,\n",
-    "        node_color=node_colors,\n",
-    "        edge_color=\"gray\",\n",
-    "        node_size=150,\n",
-    "        font_size=8,\n",
-    "        width=2,\n",
-    "    )\n",
+    "    # Draw nodes and labels\n",
+    "    for node in G:\n",
+    "        x, y = pos[node]\n",
+    "        color = \"tab:blue\" if node in outer_set else \"tab:orange\"\n",
+    "        ax.scatter(x, y, color=color, s=150, zorder=2)\n",
+    "        ax.text(\n",
+    "            x, y, str(node), ha=\"center\", va=\"center\", fontsize=8, zorder=3\n",
+    "        )\n",
+    "\n",
     "    ax.set_title(title)\n",
     "    ax.set_aspect(\"equal\")\n",
-    "    # ax.axis(\"off\")\n",
     "\n",
     "\n",
     "fig, ax = double_pannel()\n",
@@ -1186,11 +1181,11 @@
     "**Figure 9**. Two multi-componnet isomorphic graphs, plotted using their coordinate information.\n",
     "\n",
     "As far a graph theory is concerned, the two graphs above are equivalent.\n",
-    "Because the coordinate information to plot these graphs, we can see an important distinction: the graph on the left is nested where the graph on the right is separated. \n",
+    "Because we use the coordinate information to plot these graphs, we can see an important distinction: the graph on the left is nested where the graph on the right is separated. \n",
     "\n",
     "For filled contours, **Figure 9.** is a crude, but illustrative, example of a contour with an interior boundary.\n",
     "So far we only used the mesh connectivity information to create the unfilled contour boundaries, where coordinate information has only been used to plotting.\n",
-    "**But**, for filled contours after creating the contour boundaries from the connectivity information, we'll need to use coordinate info to recursive search of interior boundaries within the resulting contours.\n",
+    "**But**, for filled contours after creating the contour boundaries from the connectivity information, we'll need to use coordinate info to recursively search of interior boundaries within the resulting contours.\n",
     "\n",
     "We can efficiently recursively search for interior boundaries using [`shapely.STRtree`](https://shapely.readthedocs.io/en/stable/strtree.html#shapely.STRtree), which uses the bounding boxes of each geometry to query for containment. \n",
     "\n",
@@ -1626,7 +1621,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.9"
+   "version": "3.14.3"
   },
   "mystnb": {
    "output_align": "center"

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,11 +25,12 @@ user_guide/periodic_mesh_support
 ```
 
 ```{toctree}
-:maxdepth: 2
+:maxdepth: 1
 :caption: Developers Guide:
 
 developers_guide/quick_start
 developers_guide/api
+developers_guide/design_docs
 ```
 
 ```{toctree}

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,7 @@ If you suspect you've found a bug in `mosaic` feel free to open an issue on
 user_guide/quick_start
 user_guide/spherical_mesh_support
 user_guide/periodic_mesh_support
+user_guide/contouring
 ```
 
 ```{toctree}

--- a/docs/user_guide/contouring.ipynb
+++ b/docs/user_guide/contouring.ipynb
@@ -7,8 +7,8 @@
    "source": [
     "# Contouring on the MPAS Mesh\n",
     "\n",
-    "`mosaic` enables contouring on the native through the {func}`mosaic.contour` and {func}`mosaic.contourf` functions.\n",
-    "All keyword arguments (that apply to our unstructured contouring) are shared with the matplotib [implementations](https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.contour.html#matplotlib.axes.Axes.contour) of `contour` and `contourf`.\n",
+    "`mosaic` enables contouring on the native mesh through the {func}`mosaic.contour` and {func}`mosaic.contourf` functions.\n",
+    "All keyword arguments (that apply to our unstructured contouring) are shared with the matplotlib [implementations](https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.contour.html#matplotlib.axes.Axes.contour) of `contour` and `contourf`.\n",
     "Please consult the matplotlib docs for more [examples](https://matplotlib.org/stable/gallery/images_contours_and_fields/contour_demo.html) of fine grained control. "
    ]
   },

--- a/docs/user_guide/contouring.ipynb
+++ b/docs/user_guide/contouring.ipynb
@@ -1,0 +1,139 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# Contouring on the MPAS Mesh\n",
+    "\n",
+    "`mosaic` enables contouring on the native through the {func}`mosaic.contour` and {func}`mosaic.contourf` functions.\n",
+    "All keyword arguments (that apply to our unstructured contouring) are shared with the matplotib [implementations](https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.contour.html#matplotlib.axes.Axes.contour) of `contour` and `contourf`.\n",
+    "Please consult the matplotlib docs for more [examples](https://matplotlib.org/stable/gallery/images_contours_and_fields/contour_demo.html) of fine grained control. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from __future__ import annotations\n",
+    "\n",
+    "import cartopy.crs as ccrs\n",
+    "import cartopy.feature as cfeature\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "import mosaic\n",
+    "\n",
+    "projection = ccrs.Mollweide()\n",
+    "\n",
+    "ds = mosaic.datasets.open_dataset(\"QU.240km\")\n",
+    "descriptor = mosaic.Descriptor(ds, projection=projection)\n",
+    "\n",
+    "# extract temperature of top vertical layer\n",
+    "top_layer_temp = ds.temperature.isel(nVertLevels=0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2",
+   "metadata": {},
+   "source": [
+    "### Unfilled Contours"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(\n",
+    "    constrained_layout=True, subplot_kw={\"projection\": projection}\n",
+    ")\n",
+    "\n",
+    "mcs = mosaic.contour(\n",
+    "    ax,\n",
+    "    descriptor,\n",
+    "    top_layer_temp,\n",
+    ")\n",
+    "\n",
+    "ax.clabel(mcs)\n",
+    "\n",
+    "ax.add_feature(cfeature.LAND, fc=\"grey\", zorder=-1, alpha=0.8);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4",
+   "metadata": {},
+   "source": [
+    "### Filled Contours"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(\n",
+    "    constrained_layout=True, subplot_kw={\"projection\": projection}\n",
+    ")\n",
+    "\n",
+    "mcs = mosaic.contourf(\n",
+    "    ax,\n",
+    "    descriptor,\n",
+    "    top_layer_temp,\n",
+    ")\n",
+    "\n",
+    "mcs2 = mosaic.contour(\n",
+    "    ax, descriptor, top_layer_temp, levels=mcs.levels[::2], colors=\"k\"\n",
+    ")\n",
+    "ax.clabel(mcs2)\n",
+    "\n",
+    "ax.add_feature(cfeature.LAND, fc=\"grey\", zorder=-1, alpha=0.8)\n",
+    "\n",
+    "# Make a colorbar for the contourf call.\n",
+    "cbar = fig.colorbar(\n",
+    "    mcs, shrink=0.5, label=r\"Top Layer Temperature [$^\\circ$ C]\"\n",
+    ")\n",
+    "# Add the contour line levels to the colorbar\n",
+    "cbar.add_lines(mcs2);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/mosaic/__init__.py
+++ b/mosaic/__init__.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from mosaic import datasets
+from mosaic.contour import contour, contourf
 from mosaic.descriptor import Descriptor
 from mosaic.polypcolor import polypcolor
 
-__all__ = ["Descriptor", "datasets", "polypcolor"]
+__all__ = ["Descriptor", "contour", "contourf", "datasets", "polypcolor"]

--- a/mosaic/contour.py
+++ b/mosaic/contour.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import matplotlib.path as mpath
+import networkx as nx
+import numpy as np
+import shapely
+from matplotlib.contour import ContourSet
+from shapely import Polygon, STRtree, prepare
+
+
+def contour(ax, *args, **kwargs):
+    """
+    Plot contour lines.
+
+    Call signature::
+        contour(ax, descriptor, Z, [levels], **kwargs)
+    """
+    kwargs["filled"] = False
+    contours = MPASContourSet(ax, *args, **kwargs)
+    ax._request_autoscale_view()
+    return contours
+
+
+def contourf(ax, *args, **kwargs):
+    """
+    Plot contour lines.
+
+    Call signature::
+        contour(ax, descriptor, Z, [levels], **kwargs)
+    """
+    kwargs["filled"] = True
+    contours = MPASContourSet(ax, *args, **kwargs)
+    ax._request_autoscale_view()
+    return contours
+
+
+class MPASContourSet(ContourSet):
+    """ """
+
+    def _process_args(self, *args, **kwargs):
+        """ """
+        descriptor, z, *args = args
+
+        self.zmax = z.max().astype(float)
+        self.zmin = z.min().astype(float)
+
+        self._process_contour_level_args(args, z.dtype)
+
+        self._contour_generator = MPASContourGenerator(descriptor, z)
+
+        xCell = descriptor.ds.xCell
+        yCell = descriptor.ds.yCell
+
+        self._mins = [xCell.min(), yCell.min()]
+        self._maxs = [xCell.max(), yCell.max()]
+
+        return kwargs
+
+
+class MPASContourGenerator:
+    def __init__(self, descriptor, z):
+        self.ds = descriptor.ds
+        self._z = z
+
+        self.boundary_edge_mask = (self.ds.cellsOnEdge == -1).any("TWO").values
+        self.boundary_vertices = np.unique(
+            self.ds.verticesOnEdge[self.boundary_edge_mask]
+        )
+
+    def create_filled_contour(self, lower_level: float, upper_level: float):
+        """ """
+
+        lower_level, upper_level = self.check_levels(lower_level, upper_level)
+
+        mask = (self._z > lower_level) & (self._z < upper_level)
+
+        graph = self._create_contour_graph(mask, filled=True)
+        polys = self._split_and_order_graph(graph)
+        codes = self._assemble_contour_codes(polys)
+
+        polys, codes = self._sort_filled_contours(polys, codes)
+
+        return polys, codes
+
+    def create_contour(self, level: float):
+        """ """
+        mask = self._z > level
+
+        graph = self._create_contour_graph(mask, filled=False)
+        lines = self._split_and_order_graph(graph)
+        codes = self._assemble_contour_codes(lines)
+
+        return lines, codes
+
+    def _create_contour_graph(self, mask, filled: bool):
+        """ """
+        ds = self.ds
+
+        # mark mask as False for all cells outside domain
+        cells_on_edge_mask = np.where(
+            ds.cellsOnEdge == -1, False, mask[ds.cellsOnEdge]
+        )
+
+        # boolean mask for edges along contour
+        edge_mask = np.logical_xor.reduce(cells_on_edge_mask, axis=1)
+
+        if not filled:
+            # unfilled contours should not follow mesh boundaries
+            edge_mask = edge_mask & ~self.boundary_edge_mask
+
+        # get the vertices
+        vertex_1 = ds.verticesOnEdge[edge_mask].isel(TWO=0).values
+        vertex_2 = ds.verticesOnEdge[edge_mask].isel(TWO=1).values
+
+        # create a graph from the boundary edges
+        graph = nx.Graph()
+        graph.add_edges_from(zip(vertex_1, vertex_2, strict=False))
+
+        return graph
+
+    def _split_and_order_graph(self, graph):
+        """ """
+        ds = self.ds
+
+        # empty lists where we'll store output to be returned
+        lines = []
+
+        for component in nx.connected_components(graph):
+            subgraph = graph.subgraph(component)
+
+            # What about try nx.eulerian_path
+            # pad nodes only if closed (nx.is_tree is False)
+            # also accept NetworkX Error is euler path does not exists
+            if nx.is_eulerian(subgraph):
+                contour_nodes = np.array(
+                    [u for u, v in nx.eulerian_circuit(subgraph)]
+                )
+
+                # need to close the paths
+                contour_nodes = np.pad(contour_nodes, (0, 1), mode="wrap")
+
+            else:
+                nodes = list(subgraph.nodes)
+
+                (idxs,) = np.where(np.isin(nodes, self.boundary_vertices))
+
+                if len(idxs) != 2:
+                    msg = (
+                        "Couldn't find start/end of contour that intersects "
+                        "boundary"
+                    )
+                    raise ValueError(msg)
+
+                start, end = idxs
+
+                paths = list(
+                    nx.all_simple_paths(subgraph, nodes[start], nodes[end])
+                )
+
+                if len(list(paths)) != 1:
+                    msg = "More than one path through boundary graph found"
+                    raise ValueError(msg)
+
+                contour_nodes = paths[0]
+
+            _lines = np.stack(
+                [ds.xVertex[contour_nodes], ds.yVertex[contour_nodes]], -1
+            )
+
+            lines.append(_lines)
+
+        return lines
+
+    def _assemble_contour_codes(self, contours: list):
+        """ """
+        codes = []
+
+        line_to = mpath.Path.LINETO
+        move_to = mpath.Path.MOVETO
+        code_dtype = mpath.Path.code_type
+
+        for contour in contours:
+            _codes = np.ones(len(contour), dtype=code_dtype) * line_to
+            _codes[0] = move_to
+
+            codes.append(_codes)
+
+        return codes
+
+    def _sort_filled_contours(self, polys, codes):
+        """ """
+        polygons = list(map(Polygon, polys))
+        # prepare returns None, so do not assign
+        [prepare(p) for p in polygons]
+
+        n_polygons = len(polygons)
+
+        # create a tree...
+        tree = STRtree(polygons)
+
+        idx = tree.query(polygons, predicate="contains_properly")
+
+        # TODO: Add condition for empty idx
+        parents, children = idx
+
+        # how many polygons contain i-th polygon
+        depth = np.bincount(children, minlength=n_polygons)
+
+        if any(depth > 1):
+            msg = "Cannot Properly Handle Nested Interior Boundaries Yet"
+            raise ValueError(msg)
+
+        _polys = []
+        _codes = []
+
+        for p in set(parents):
+            c = children[parents == p]
+
+            p_ccw = _is_ccw(polygons[p])
+            strides = [_stride(p_ccw, _is_ccw(polygons[i])) for i in c]
+
+            ext_poly = [polys[p]]
+            int_polys = [
+                polys[i][::s] for i, s in zip(c, strides, strict=False)
+            ]
+
+            ext_codes = [codes[p]]
+            int_codes = [codes[i] for i in c]
+
+            _polys.append(np.vstack(ext_poly + int_polys))
+            _codes.append(np.hstack(ext_codes + int_codes))
+
+        others_set = set(np.concat([parents, children]))
+        others_idx = others_set.symmetric_difference(set(range(n_polygons)))
+
+        _polys.extend([polys[i] for i in others_idx])
+        _codes.extend([codes[i] for i in others_idx])
+
+        return _polys, _codes
+
+    def check_levels(self, upper_level, lower_level):
+        """ """
+        # TODO: checked filled are monotonic
+        # TODO: check no nan's
+
+        return upper_level, lower_level
+
+
+def _is_ccw(polygon) -> bool:
+    return shapely.is_ccw(polygon.exterior)
+
+
+def _stride(is_parent_ccw: bool, is_child_ccw: bool) -> int:
+    return 2 * int(is_parent_ccw != is_child_ccw) - 1

--- a/mosaic/contour.py
+++ b/mosaic/contour.py
@@ -263,7 +263,7 @@ class MPASContourGenerator:
 
         lower_level, upper_level = self.check_levels(lower_level, upper_level)
 
-        mask = (self._z > lower_level) & (self._z < upper_level)
+        mask = (self._z > lower_level) & (self._z <= upper_level)
 
         graph = self._create_contour_graph(mask, filled=True)
         polys = self._split_and_order_graph(graph)

--- a/mosaic/contour.py
+++ b/mosaic/contour.py
@@ -209,46 +209,63 @@ class MPASContourGenerator:
 
         n_polygons = len(polygons)
 
-        # create a tree...
         tree = STRtree(polygons)
 
         idx = tree.query(polygons, predicate="contains_properly")
 
-        # TODO: Add condition for empty idx
-        parents, children = idx
+        if idx.size == 0:
+            return polys, codes
 
-        # how many polygons contain i-th polygon
-        depth = np.bincount(children, minlength=n_polygons)
+        all_parents, all_children = idx
 
-        if any(depth > 1):
-            msg = "Cannot Properly Handle Nested Interior Boundaries Yet"
-            raise ValueError(msg)
+        # Nesting depth: number of polygons that contain polygon i.
+        depth = np.bincount(all_children, minlength=n_polygons)
+
+        # For each child, find its direct parent: the containing polygon with
+        # the greatest depth (i.e., the closest/tightest enclosing polygon).
+        direct_parent = np.full(n_polygons, -1, dtype=int)
+        for p, c in zip(all_parents, all_children, strict=False):
+            if direct_parent[c] == -1 or depth[p] > depth[direct_parent[c]]:
+                direct_parent[c] = p
 
         _polys = []
         _codes = []
+        processed = set()
 
-        for p in set(parents):
-            c = children[parents == p]
+        # Even-depth polygons are exterior rings; their direct (odd-depth)
+        # children are interior holes. Odd-depth polygons inside even-depth
+        # holes are new exterior rings at depth+1, handled in a later iteration.
+        for i in range(n_polygons):
+            if depth[i] % 2 == 0:
+                p_ccw = _is_ccw(polygons[i])
+                c_list = np.where(direct_parent == i)[0]
 
-            p_ccw = _is_ccw(polygons[p])
-            strides = [_stride(p_ccw, _is_ccw(polygons[i])) for i in c]
+                strides = [
+                    _stride(p_ccw, _is_ccw(polygons[j])) for j in c_list
+                ]
 
-            ext_poly = [polys[p]]
-            int_polys = [
-                polys[i][::s] for i, s in zip(c, strides, strict=False)
-            ]
+                ext_poly = [polys[i]]
+                int_polys = [
+                    polys[j][::s]
+                    for j, s in zip(c_list, strides, strict=False)
+                ]
 
-            ext_codes = [codes[p]]
-            int_codes = [codes[i] for i in c]
+                ext_codes = [codes[i]]
+                int_codes = [codes[j] for j in c_list]
 
-            _polys.append(np.vstack(ext_poly + int_polys))
-            _codes.append(np.hstack(ext_codes + int_codes))
+                _polys.append(np.vstack(ext_poly + int_polys))
+                _codes.append(np.hstack(ext_codes + int_codes))
 
-        others_set = set(np.concat([parents, children]))
-        others_idx = others_set.symmetric_difference(set(range(n_polygons)))
+                # adds exterior ring
+                processed.add(i)
+                # adds interior holes
+                processed.update(c_list.tolist())
 
-        _polys.extend([polys[i] for i in others_idx])
-        _codes.extend([codes[i] for i in others_idx])
+        # Catch any polygons not handled above
+        for i in range(n_polygons):
+            if i not in processed:
+                _polys.append(polys[i])
+                _codes.append(codes[i])
 
         return _polys, _codes
 

--- a/mosaic/contour.py
+++ b/mosaic/contour.py
@@ -5,7 +5,10 @@ import networkx as nx
 import numpy as np
 import shapely
 from matplotlib.contour import ContourSet
+from numpy.typing import ArrayLike
 from shapely import Polygon, STRtree, prepare
+
+from mosaic.descriptor import Descriptor
 
 
 def contour(ax, *args, **kwargs):
@@ -58,7 +61,7 @@ class MPASContourSet(ContourSet):
 
 
 class MPASContourGenerator:
-    def __init__(self, descriptor, z):
+    def __init__(self, descriptor: Descriptor, z: ArrayLike):
         loc, array = descriptor._get_array_location(z)
         if loc != "cell":
             msg = f"Contour levels must be defined on cell centers, not {loc}"
@@ -72,7 +75,9 @@ class MPASContourGenerator:
             self.ds.verticesOnEdge[self.boundary_edge_mask]
         )
 
-    def create_filled_contour(self, lower_level: float, upper_level: float):
+    def create_filled_contour(
+        self, lower_level: float, upper_level: float
+    ) -> tuple[list[np.ndarray], list[int]]:
         """ """
 
         lower_level, upper_level = self.check_levels(lower_level, upper_level)
@@ -87,7 +92,9 @@ class MPASContourGenerator:
 
         return polys, codes
 
-    def create_contour(self, level: float):
+    def create_contour(
+        self, level: float
+    ) -> tuple[list[np.ndarray], list[int]]:
         """ """
         mask = self._z > level
 
@@ -97,7 +104,9 @@ class MPASContourGenerator:
 
         return lines, codes
 
-    def _create_contour_graph(self, mask, filled: bool):
+    def _create_contour_graph(
+        self, mask: np.ndarray, filled: bool
+    ) -> nx.Graph:
         """ """
         ds = self.ds
 
@@ -122,10 +131,11 @@ class MPASContourGenerator:
 
         return graph
 
-    def _split_and_order_graph(self, graph):
+    def _split_and_order_graph(self, graph: nx.Graph) -> list[np.ndarray]:
         """ """
 
-        # TODO: if graph is empty return
+        if nx.is_empty(graph):
+            return []
 
         x_vertex = self.ds.xVertex.values
         y_vertex = self.ds.yVertex.values
@@ -186,10 +196,11 @@ class MPASContourGenerator:
 
         return lines
 
-    def _assemble_contour_codes(self, contours: list):
+    def _assemble_contour_codes(self, contours: list[np.ndarray]) -> list[int]:
         """ """
 
-        # TODO: if graph is empty return
+        if len(contours) == 0:
+            return []
 
         codes = []
 
@@ -205,13 +216,18 @@ class MPASContourGenerator:
 
         return codes
 
-    def _sort_filled_contours(self, polys, codes):
+    def _sort_filled_contours(
+        self, polys: list[np.ndarray], codes: list[int]
+    ) -> tuple[list[np.ndarray], list[int]]:
         """ """
         polygons = list(map(Polygon, polys))
         # prepare returns None, so do not assign
         [prepare(p) for p in polygons]
 
         n_polygons = len(polygons)
+
+        if n_polygons == 0:
+            return polys, codes
 
         tree = STRtree(polygons)
 
@@ -273,7 +289,9 @@ class MPASContourGenerator:
 
         return _polys, _codes
 
-    def check_levels(self, upper_level, lower_level):
+    def check_levels(
+        self, upper_level: float, lower_level: float
+    ) -> tuple[float, float]:
         """ """
         # TODO: checked filled are monotonic
         # TODO: check no nan's
@@ -281,7 +299,7 @@ class MPASContourGenerator:
         return upper_level, lower_level
 
 
-def _is_ccw(polygon) -> bool:
+def _is_ccw(polygon: Polygon) -> bool:
     return shapely.is_ccw(polygon.exterior)
 
 

--- a/mosaic/contour.py
+++ b/mosaic/contour.py
@@ -48,11 +48,11 @@ class MPASContourSet(ContourSet):
 
         self._contour_generator = MPASContourGenerator(descriptor, z)
 
-        xCell = descriptor.ds.xCell
-        yCell = descriptor.ds.yCell
+        x_vertex = descriptor.ds.xVertex
+        y_vertex = descriptor.ds.yVertex
 
-        self._mins = [xCell.min(), yCell.min()]
-        self._maxs = [xCell.max(), yCell.max()]
+        self._mins = [x_vertex.min(), y_vertex.min()]
+        self._maxs = [x_vertex.max(), y_vertex.max()]
 
         return kwargs
 

--- a/mosaic/contour.py
+++ b/mosaic/contour.py
@@ -65,7 +65,7 @@ class MPASContourGenerator:
             raise ValueError(msg)
 
         self.ds = descriptor.ds
-        self._z = array
+        self._z = np.asarray(array)
 
         self.boundary_edge_mask = (self.ds.cellsOnEdge == -1).any("TWO").values
         self.boundary_vertices = np.unique(
@@ -125,51 +125,60 @@ class MPASContourGenerator:
 
     def _split_and_order_graph(self, graph):
         """ """
-        ds = self.ds
+
+        x_vertex = self.ds.xVertex.values
+        y_vertex = self.ds.yVertex.values
 
         # empty lists where we'll store output to be returned
         lines = []
 
+        # local binding
+        dfs_pre = nx.dfs_preorder_nodes
+        graph_degree = graph.degree()
+
         for component in nx.connected_components(graph):
-            subgraph = graph.subgraph(component)
+            if len(component) == 1:
+                node = next(iter(component))
+                msg = f"Invalid contour component: singleton node {node}"
+                raise ValueError(msg)
 
-            # What about try nx.eulerian_path
-            # pad nodes only if closed (nx.is_tree is False)
-            # also accept NetworkX Error is euler path does not exists
-            if nx.is_eulerian(subgraph):
-                contour_nodes = np.array(
-                    [u for u, v in nx.eulerian_circuit(subgraph)]
+            # With max degree <= 2, endpoints are exactly degree-1 nodes
+            endpoints = [v for v in component if graph_degree[v] == 1]
+
+            # cycle (i.e. closed loop)
+            if len(endpoints) == 0:
+                contour_nodes = list(
+                    dfs_pre(graph, source=next(iter(component)))
                 )
+                contour_nodes.append(contour_nodes[0])
 
-                # need to close the paths
-                contour_nodes = np.pad(contour_nodes, (0, 1), mode="wrap")
+            # path (i.e. unclosed loop)
+            elif len(endpoints) == 2:
+                # set intersection
+                boundary_nodes = [
+                    v for v in endpoints if v in self.boundary_vertices
+                ]
 
-            else:
-                nodes = list(subgraph.nodes)
-
-                (idxs,) = np.where(np.isin(nodes, self.boundary_vertices))
-
-                if len(idxs) != 2:
+                if len(boundary_nodes) != 2:
                     msg = (
                         "Couldn't find start/end of contour that intersects "
                         "boundary"
                     )
                     raise ValueError(msg)
 
-                start, end = idxs
+                start, _ = boundary_nodes
 
-                paths = list(
-                    nx.all_simple_paths(subgraph, nodes[start], nodes[end])
+                contour_nodes = list(dfs_pre(graph, source=start))
+            else:
+                node = next(iter(component))
+                msg = (
+                    f"Invalid contour component: node ({node}) degree is not"
+                    f"1 or 2. Instead is {len(endpoints)}"
                 )
-
-                if len(list(paths)) != 1:
-                    msg = "More than one path through boundary graph found"
-                    raise ValueError(msg)
-
-                contour_nodes = paths[0]
+                raise ValueError(msg)
 
             _lines = np.stack(
-                [ds.xVertex[contour_nodes], ds.yVertex[contour_nodes]], -1
+                [x_vertex[contour_nodes], y_vertex[contour_nodes]], -1
             )
 
             lines.append(_lines)

--- a/mosaic/contour.py
+++ b/mosaic/contour.py
@@ -59,8 +59,13 @@ class MPASContourSet(ContourSet):
 
 class MPASContourGenerator:
     def __init__(self, descriptor, z):
+        loc, array = descriptor._get_array_location(z)
+        if loc != "cell":
+            msg = f"Contour levels must be defined on cell centers, not {loc}"
+            raise ValueError(msg)
+
         self.ds = descriptor.ds
-        self._z = z
+        self._z = array
 
         self.boundary_edge_mask = (self.ds.cellsOnEdge == -1).any("TWO").values
         self.boundary_vertices = np.unique(

--- a/mosaic/contour.py
+++ b/mosaic/contour.py
@@ -77,7 +77,7 @@ class MPASContourGenerator:
 
     def create_filled_contour(
         self, lower_level: float, upper_level: float
-    ) -> tuple[list[np.ndarray], list[int]]:
+    ) -> tuple[list[np.ndarray], list[np.ndarray]]:
         """ """
 
         lower_level, upper_level = self.check_levels(lower_level, upper_level)
@@ -94,7 +94,7 @@ class MPASContourGenerator:
 
     def create_contour(
         self, level: float
-    ) -> tuple[list[np.ndarray], list[int]]:
+    ) -> tuple[list[np.ndarray], list[np.ndarray]]:
         """ """
         mask = self._z > level
 
@@ -196,7 +196,9 @@ class MPASContourGenerator:
 
         return lines
 
-    def _assemble_contour_codes(self, contours: list[np.ndarray]) -> list[int]:
+    def _assemble_contour_codes(
+        self, contours: list[np.ndarray]
+    ) -> list[np.ndarray]:
         """ """
 
         if len(contours) == 0:
@@ -218,7 +220,7 @@ class MPASContourGenerator:
 
     def _sort_filled_contours(
         self, polys: list[np.ndarray], codes: list[int]
-    ) -> tuple[list[np.ndarray], list[int]]:
+    ) -> tuple[list[np.ndarray], list[np.ndarray]]:
         """ """
         polygons = list(map(Polygon, polys))
         # prepare returns None, so do not assign

--- a/mosaic/contour.py
+++ b/mosaic/contour.py
@@ -34,8 +34,8 @@ Z : array-like
 levels : int or array-like, optional
     Determines the number and positions of the contour lines / regions.
 
-    If an int *n*, use :py:class:`~matplotlib.ticker.MaxNLocator`, which tries to
-    automatically choose no more than *n+2* "nice" contour level
+    If an int *n*, use :py:class:`~matplotlib.ticker.MaxNLocator`, which tries
+    to automatically choose no more than *n+2* "nice" contour level
     boundaries between the minimum and maximum values of *Z*.
 
     If array-like, draw contour lines at the specified levels.  The
@@ -45,7 +45,7 @@ levels : int or array-like, optional
 
 Returns
 -------
-:py:class:`MPASContourSet`
+:py:class:`~mosaic.contour.MPASContourSet`
 
 Other Parameters
 ----------------
@@ -203,7 +203,22 @@ def contourf(ax, *args, **kwargs):
 
 
 class MPASContourSet(ContourSet):
-    """ """
+    """
+    A :class:`matplotlib.contour.ContourSet` subclass for MPAS meshes.
+
+    This contour set is created by :func:`mosaic.contour` and
+    :func:`mosaic.contourf` to draw contour lines and filled contours on an
+    unstructured MPAS mesh.
+
+    Compared to :class:`matplotlib.contour.ContourSet`, the first
+    positional argument is expected to be a
+    :class:`~mosaic.descriptor.Descriptor` describing the MPAS mesh,
+    and the contour generator is provided by
+    :class:`MPASContourGenerator`.
+
+    Users normally do not instantiate this class directly; instead,
+    call :func:`mosaic.contour` or :func:`mosaic.contourf`.
+    """
 
     def _process_args(self, *args, **kwargs):
         """ """
@@ -217,8 +232,8 @@ class MPASContourSet(ContourSet):
 
         self._contour_generator = MPASContourGenerator(descriptor, z)
 
-        x_vertex = descriptor.ds.xVertex
-        y_vertex = descriptor.ds.yVertex
+        x_vertex = np.asarray(descriptor.ds.xVertex)
+        y_vertex = np.asarray(descriptor.ds.yVertex)
 
         self._mins = [x_vertex.min(), y_vertex.min()]
         self._maxs = [x_vertex.max(), y_vertex.max()]
@@ -326,7 +341,7 @@ class MPASContourGenerator:
 
                 if len(boundary_nodes) != 2:
                     msg = (
-                        "Couldn't find start/end of contour that intersects "
+                        "Couldn't find start/end of contour that intersects"
                         "boundary"
                     )
                     raise ValueError(msg)
@@ -372,7 +387,7 @@ class MPASContourGenerator:
         return codes
 
     def _sort_filled_contours(
-        self, polys: list[np.ndarray], codes: list[int]
+        self, polys: list[np.ndarray], codes: list[np.ndarray]
     ) -> tuple[list[np.ndarray], list[np.ndarray]]:
         """ """
         polygons = list(map(Polygon, polys))
@@ -409,7 +424,7 @@ class MPASContourGenerator:
 
         # Even-depth polygons are exterior rings; their direct (odd-depth)
         # children are interior holes. Odd-depth polygons inside even-depth
-        # holes are new exterior rings at depth+1, handled in a later iteration.
+        # holes are new exterior rings at depth+1, handled in a later iteration
         for i in range(n_polygons):
             if depth[i] % 2 == 0:
                 p_ccw = _is_ccw(polygons[i])

--- a/mosaic/contour.py
+++ b/mosaic/contour.py
@@ -44,6 +44,7 @@ class MPASContourSet(ContourSet):
     def _process_args(self, *args, **kwargs):
         """ """
         descriptor, z, *args = args
+        z = np.asarray(z)
 
         self.zmax = z.max().astype(float)
         self.zmin = z.min().astype(float)

--- a/mosaic/contour.py
+++ b/mosaic/contour.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
+
 import matplotlib.path as mpath
-import networkx as nx
 import numpy as np
 import shapely
 from matplotlib.contour import ContourSet
@@ -106,7 +107,7 @@ class MPASContourGenerator:
 
     def _create_contour_graph(
         self, mask: np.ndarray, filled: bool
-    ) -> nx.Graph:
+    ) -> ContourGraph:
         """ """
         ds = self.ds
 
@@ -125,47 +126,35 @@ class MPASContourGenerator:
         vertex_1 = ds.verticesOnEdge[edge_mask].isel(TWO=0).values
         vertex_2 = ds.verticesOnEdge[edge_mask].isel(TWO=1).values
 
-        # create a graph from the boundary edges
-        graph = nx.Graph()
-        graph.add_edges_from(zip(vertex_1, vertex_2, strict=False))
+        return ContourGraph(vertex_1, vertex_2)
 
-        return graph
-
-    def _split_and_order_graph(self, graph: nx.Graph) -> list[np.ndarray]:
+    def _split_and_order_graph(self, graph: ContourGraph) -> list[np.ndarray]:
         """ """
 
-        if nx.is_empty(graph):
+        if not graph:
             return []
 
         x_vertex = self.ds.xVertex.values
         y_vertex = self.ds.yVertex.values
 
-        # empty lists where we'll store output to be returned
         lines = []
 
-        # local binding
-        dfs_pre = nx.dfs_preorder_nodes
-        graph_degree = graph.degree()
-
-        for component in nx.connected_components(graph):
+        for component in graph.components():
             if len(component) == 1:
                 node = next(iter(component))
                 msg = f"Invalid contour component: singleton node {node}"
                 raise ValueError(msg)
 
             # With max degree <= 2, endpoints are exactly degree-1 nodes
-            endpoints = [v for v in component if graph_degree[v] == 1]
+            endpoints = [v for v in component if graph.degree(v) == 1]
 
             # cycle (i.e. closed loop)
             if len(endpoints) == 0:
-                contour_nodes = list(
-                    dfs_pre(graph, source=next(iter(component)))
-                )
+                contour_nodes = graph.walk(next(iter(component)))
                 contour_nodes.append(contour_nodes[0])
 
             # path (i.e. unclosed loop)
             elif len(endpoints) == 2:
-                # set intersection
                 boundary_nodes = [
                     v for v in endpoints if v in self.boundary_vertices
                 ]
@@ -178,8 +167,7 @@ class MPASContourGenerator:
                     raise ValueError(msg)
 
                 start, _ = boundary_nodes
-
-                contour_nodes = list(dfs_pre(graph, source=start))
+                contour_nodes = graph.walk(start)
             else:
                 node = next(iter(component))
                 msg = (
@@ -299,6 +287,144 @@ class MPASContourGenerator:
             raise ValueError(msg)
 
         return lower_level, upper_level
+
+
+class ContourGraph:
+    """Lightweight undirected graph for MPAS contour traversal.
+
+    Represents the set of mesh line segments that form a contour level as an
+    adjacency-list graph. Each connected component is guaranteed to be either
+    a path graph (an open arc whose endpoints lie on the domain boundary) or a
+    cycle graph (a closed loop entirely within the domain interior). Both
+    topologies have maximum node degree two, which makes full graph-library
+    machinery unnecessary.
+
+    Parameters
+    ----------
+    v1, v2 : np.ndarray
+        Parallel arrays of vertex IDs defining the contour edges.  Each pair
+        ``(v1[i], v2[i])`` is an undirected edge.
+    """
+
+    def __init__(self, v1: np.ndarray, v2: np.ndarray) -> None:
+        adj: dict[int, list[int]] = {}
+        for u, v in zip(v1, v2, strict=True):
+            adj.setdefault(u, []).append(v)
+            adj.setdefault(v, []).append(u)
+        self._adj = adj
+
+    def __bool__(self) -> bool:
+        return bool(self._adj)
+
+    def __iter__(self) -> Iterator[int]:
+        return iter(self._adj)
+
+    def degree(self, node: int) -> int:
+        """Return the degree (number of neighbors) of *node*."""
+        return len(self._adj[node])
+
+    def components(self) -> Iterator[set[int]]:
+        """Yield each connected component as a set of node IDs.
+
+        Uses an iterative depth-first flood fill so that the call stack is
+        never deeper than O(1) regardless of component size.
+
+        Yields
+        ------
+        set[int]
+            Node IDs belonging to one connected component.  Components are
+            yielded in the order their seed node is first encountered during
+            iteration over the adjacency dict.
+
+        References
+        ----------
+        .. [1] "Component (graph theory)", Wikipedia,
+               https://en.wikipedia.org/wiki/Component_(graph_theory)
+        .. [2] "Depth-first search", Wikipedia,
+               https://en.wikipedia.org/wiki/Depth-first_search
+        """
+        visited: set[int] = set()
+        for seed in self._adj:
+            if seed in visited:
+                continue
+            component: set[int] = set()
+            stack = [seed]
+            while stack:
+                node = stack.pop()
+                if node in visited:
+                    continue
+                visited.add(node)
+                component.add(node)
+                stack.extend(self._adj[node])
+            yield component
+
+    def walk(self, start: int) -> list[int]:
+        """Return a ordered list of node IDs by traversing from *start*.
+
+        Because every node has degree <= 2, there is at most one unvisited
+        neighbor at each step, reducing traversal to a simple linear chain
+        walk.  The method handles both path graphs (open chains) and cycle
+        graphs (closed loops); for cycles the caller is responsible for
+        appending ``path[0]`` to close the loop.
+
+        Parameters
+        ----------
+        start : int
+            The node ID from which to begin the walk.  For path components
+            this should be one of the two degree-1 endpoints; for cycle
+            components any node may be used.
+
+        Returns
+        -------
+        list[int]
+            Node IDs in traversal order, beginning with *start*.
+
+        References
+        ----------
+        .. [1] "Path graph", Wikipedia,
+               https://en.wikipedia.org/wiki/Path_graph
+        .. [2] "Cycle graph", Wikipedia,
+               https://en.wikipedia.org/wiki/Cycle_graph
+        """
+        path, seen, cur = [start], {start}, start
+        while nxt := [n for n in self._adj[cur] if n not in seen]:
+            cur = nxt[0]
+            path.append(cur)
+            seen.add(cur)
+        return path
+
+    def to_networkx(self):
+        """Convert to a :class:`networkx.Graph` for testing and inspection.
+
+        networkx is an testing dependency and is not required for normal use
+
+        Returns
+        -------
+        networkx.Graph
+            An undirected graph with the same nodes and edges.
+
+        Raises
+        ------
+        ImportError
+            If networkx is not installed.
+        """
+        try:
+            import networkx as nx  # noqa: PLC0415
+        except ImportError as e:
+            msg = (
+                "networkx is required to call to_networkx(). "
+                "Install it with: pip install networkx"
+            )
+            raise ImportError(msg) from e
+
+        g = nx.Graph()
+        g.add_edges_from(
+            (u, v)
+            for u, neighbors in self._adj.items()
+            for v in neighbors
+            if u < v
+        )
+        return g
 
 
 def _is_ccw(polygon: Polygon) -> bool:

--- a/mosaic/contour.py
+++ b/mosaic/contour.py
@@ -101,10 +101,9 @@ class MPASContourGenerator:
         """ """
         ds = self.ds
 
+        padded_mask = np.r_[False, mask]
         # mark mask as False for all cells outside domain
-        cells_on_edge_mask = np.where(
-            ds.cellsOnEdge == -1, False, mask[ds.cellsOnEdge]
-        )
+        cells_on_edge_mask = np.asarray(padded_mask[ds.cellsOnEdge + 1])
 
         # boolean mask for edges along contour
         edge_mask = np.logical_xor.reduce(cells_on_edge_mask, axis=1)
@@ -125,6 +124,8 @@ class MPASContourGenerator:
 
     def _split_and_order_graph(self, graph):
         """ """
+
+        # TODO: if graph is empty return
 
         x_vertex = self.ds.xVertex.values
         y_vertex = self.ds.yVertex.values
@@ -187,6 +188,9 @@ class MPASContourGenerator:
 
     def _assemble_contour_codes(self, contours: list):
         """ """
+
+        # TODO: if graph is empty return
+
         codes = []
 
         line_to = mpath.Path.LINETO

--- a/mosaic/contour.py
+++ b/mosaic/contour.py
@@ -290,13 +290,13 @@ class MPASContourGenerator:
         return _polys, _codes
 
     def check_levels(
-        self, upper_level: float, lower_level: float
+        self, lower_level: float, upper_level: float
     ) -> tuple[float, float]:
-        """ """
-        # TODO: checked filled are monotonic
-        # TODO: check no nan's
+        if not lower_level < upper_level:
+            msg = "Contour levels must be increasing"
+            raise ValueError(msg)
 
-        return upper_level, lower_level
+        return lower_level, upper_level
 
 
 def _is_ccw(polygon: Polygon) -> bool:

--- a/mosaic/contour.py
+++ b/mosaic/contour.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 
+import matplotlib._docstring
 import matplotlib.path as mpath
 import numpy as np
 import shapely
@@ -11,13 +12,172 @@ from shapely import Polygon, STRtree, prepare
 
 from mosaic.descriptor import Descriptor
 
+# Single shared docstring for both contour and contourf, mirroring the
+# structure of matplotlib's contour_doc.  %(cmap_doc)s etc. are expanded
+# eagerly at definition time (same trick as matplotlib/contour.py L1702).
+_contour_doc_template = """
+:py:func:`contour` and :py:func:`contourf` draw contour lines and filled
+contours respectively on an unstructured MPAS mesh.  Except as noted,
+function signatures and return values are the same for both versions.
 
+Parameters
+----------
+descriptor : ~mosaic.Descriptor
+    MPAS mesh descriptor containing the unstructured grid connectivity and
+    coordinate arrays
+
+Z : array-like
+    Scalar field defined at cell centers over which the contour is
+    drawn.  Color-mapping is controlled by *cmap*, *norm*, *vmin*, and
+    *vmax*.
+
+levels : int or array-like, optional
+    Determines the number and positions of the contour lines / regions.
+
+    If an int *n*, use :py:class:`~matplotlib.ticker.MaxNLocator`, which tries to
+    automatically choose no more than *n+2* "nice" contour level
+    boundaries between the minimum and maximum values of *Z*.
+
+    If array-like, draw contour lines at the specified levels.  The
+    values must be in increasing order.
+
+    If not given, a reasonable default is chosen automatically.
+
+Returns
+-------
+:py:class:`MPASContourSet`
+
+Other Parameters
+----------------
+colors : :mpltype:`color` or list of :mpltype:`color`, optional
+    The colors of the levels, i.e. the lines for ``mosaic.contour`` and
+    the areas for ``mosaic.contourf``.
+
+    The sequence is cycled for the levels in ascending order. If the
+    sequence is shorter than the number of levels, it's repeated.
+
+    As a shortcut, a single color may be used in place of one-element
+    lists, i.e. ``'red'`` instead of ``['red']`` to color all levels
+    with the same color.
+
+    By default (value *None*), the colormap specified by *cmap* will be
+    used.
+
+alpha : float, default: 1
+    The alpha blending value, between 0 (transparent) and 1 (opaque).
+
+%(cmap_doc)s
+
+    This parameter is ignored if *colors* is set.
+
+%(norm_doc)s
+
+    This parameter is ignored if *colors* is set.
+
+%(vmin_vmax_doc)s
+
+    If *vmin* or *vmax* are not given, the default color scaling is
+    based on *levels*.
+
+    This parameter is ignored if *colors* is set.
+
+locator : :py:class:`~matplotlib.ticker.Locator` subclass, optional
+    The locator is used to determine the contour levels if they are not
+    given explicitly via *levels*.  Defaults to
+    `~matplotlib.ticker.MaxNLocator`.
+
+extend : {'neither', 'both', 'min', 'max'}, default: 'neither'
+    Determines the coloring of values that are outside the *levels*
+    range.
+
+    If 'neither', values outside the *levels* range are not colored.
+    If 'min', 'max' or 'both', color the values below, above or below
+    and above the *levels* range.
+
+    Values below ``min(levels)`` and above ``max(levels)`` are mapped
+    to the under/over values of the `.Colormap`.  Note that most
+    colormaps do not have dedicated colors for these by default, so
+    that the over and under values are the edge values of the colormap.
+    You may want to set these values explicitly using
+    `.Colormap.set_under` and `.Colormap.set_over`.
+
+linewidths : float or array-like, default: :rc:`contour.linewidth`
+    *Only applies to* :py:func:`contour`.
+
+    The line width of the contour lines.
+
+    If a number, all levels will be plotted with this linewidth.
+
+    If a sequence, the levels in ascending order will be plotted with
+    the linewidths in the order specified.
+
+    If *None*, this falls back to :rc:`lines.linewidth`.
+
+linestyles : {*None*, 'solid', 'dashed', 'dashdot', 'dotted'}, optional
+    *Only applies to* :py:func:`contour`.
+
+    If *linestyles* is *None*, the default is 'solid' unless the lines
+    are monochrome.  In that case, negative contours will instead take
+    their linestyle from the *negative_linestyles* argument.
+
+    *linestyles* can also be an iterable of the above strings specifying
+    a set of linestyles to be used. If this iterable is shorter than the
+    number of contour levels it will be repeated as necessary.
+
+negative_linestyles : {*None*, 'solid', 'dashed', 'dashdot', 'dotted'}, \
+optional
+    *Only applies to* :py:func:`contour`.
+
+    If *linestyles* is *None* and the lines are monochrome, this
+    argument specifies the line style for negative contours.
+
+    If *negative_linestyles* is *None*, the default is taken from
+    :rc:`contour.negative_linestyle`.
+
+hatches : list[str], optional
+    *Only applies to* :py:func:`contourf`.
+
+    A list of cross hatch patterns to use on the filled areas.  If
+    *None*, no hatching will be added to the contour.  See
+    `.Patch.set_hatch` for pattern syntax.
+
+antialiased : bool, optional
+    Enable antialiasing, overriding the defaults.  For filled contours,
+    the default is *False*.  For line contours, it is taken from
+    :rc:`lines.antialiased`.
+
+Notes
+-----
+1. ``mosaic.contourf`` does not draw polygon edges.  To draw edges, add
+   line contours with calls to `mosaic.contour`.
+
+2. ``mosaic.contourf`` fills intervals that are closed at the top; that
+   is, for boundaries *z1* and *z2*, the filled region is::
+
+      z1 < Z <= z2
+
+   except for the lowest interval, which is closed on both sides (i.e.
+   it includes the lowest value).
+
+3. Contouring is performed directly on the MPAS unstructured mesh by
+   traversing the dual graph of cell edges, without any intermediate
+   grid interpolation.
+"""
+_contour_doc = _contour_doc_template % matplotlib._docstring.interpd.params
+
+matplotlib._docstring.interpd.register(mosaic_contour_doc=_contour_doc)
+
+
+@matplotlib._docstring.interpd
 def contour(ax, *args, **kwargs):
     """
-    Plot contour lines.
+    Plot contour lines on an unstructured MPAS mesh.
 
     Call signature::
+
         contour(ax, descriptor, Z, [levels], **kwargs)
+
+    %(mosaic_contour_doc)s
     """
     kwargs["filled"] = False
     contours = MPASContourSet(ax, *args, **kwargs)
@@ -25,12 +185,16 @@ def contour(ax, *args, **kwargs):
     return contours
 
 
+@matplotlib._docstring.interpd
 def contourf(ax, *args, **kwargs):
     """
-    Plot contour lines.
+    Plot filled contours on an unstructured MPAS mesh.
 
     Call signature::
-        contour(ax, descriptor, Z, [levels], **kwargs)
+
+        contourf(ax, descriptor, Z, [levels], **kwargs)
+
+    %(mosaic_contour_doc)s
     """
     kwargs["filled"] = True
     contours = MPASContourSet(ax, *args, **kwargs)

--- a/mosaic/descriptor.py
+++ b/mosaic/descriptor.py
@@ -681,6 +681,8 @@ class Descriptor:
             "nVertices": "vertex",
         }
 
+        array = np.asarray(array)
+
         if array.ndim != 1:
             msg = f"Array should be 1-D, instead has {array.ndim} dims"
             if sum([size > 1 for size in array.shape]) > 1:

--- a/mosaic/descriptor.py
+++ b/mosaic/descriptor.py
@@ -9,6 +9,7 @@ import shapely
 import xarray as xr
 from cartopy.crs import CRS
 from numpy import ndarray
+from numpy.typing import ArrayLike
 from xarray.core.dataset import Dataset
 
 import mosaic.utils
@@ -667,6 +668,52 @@ class Descriptor:
             mirrored = None
 
         return mirrored, idxs
+
+    def _get_array_location(self, array: ArrayLike) -> tuple[str, ArrayLike]:
+        """Helper function to find mesh location where array is defined
+
+        If descriptor has been culled, also subset array to culled mesh size.
+        """
+
+        dimension_to_location = {
+            "nCells": "cell",
+            "nEdges": "edge",
+            "nVertices": "vertex",
+        }
+
+        if array.ndim != 1:
+            msg = f"Array should be 1-D, instead has {array.ndim} dims"
+            if sum([size > 1 for size in array.shape]) > 1:
+                # more than one dimensions is greater than length one
+                raise ValueError(msg)
+            array = array.squeeze()
+
+        # dict of dim lengths of the original dataset
+        origin_rev = {v: k for k, v in self.sizes.items()}
+        # dict of dim lengths of the culled dataset
+        culled_rev = {self.ds.sizes[d]: d for d in self.sizes}
+
+        # start by trying to find match in original dataset
+        dim = origin_rev.get(array.size)
+        if dim is not None:
+            loc = dimension_to_location[dim]
+            array_name = f"indexTo{loc.capitalize()}ID"
+            if array_name in self.ds:
+                lut = self.ds[array_name]
+                return loc, array[lut]
+            return loc, array
+
+        # fallback to checking culled dataset
+        dim = culled_rev.get(array.size)
+        if dim is not None:
+            # no need to look up table with culled mesh array
+            return dimension_to_location[dim], array
+
+        msg = (
+            f"Size of array {array.size} is incompatible with mesh dimensions "
+            f"{self.sizes}"
+        )
+        raise ValueError(msg)
 
 
 def _compute_cell_patches(ds: Dataset) -> ndarray:

--- a/mosaic/polypcolor.py
+++ b/mosaic/polypcolor.py
@@ -4,69 +4,10 @@ import numpy as np
 from cartopy.mpl.geoaxes import GeoAxes
 from matplotlib.axes import Axes
 from matplotlib.collections import PolyCollection
-from numpy.typing import ArrayLike
 from xarray.core.dataarray import DataArray
 
 from mosaic.descriptor import Descriptor
 from mosaic.mpas_collection import MPASCollection
-
-
-def _get_array_location(
-    descriptor: Descriptor, array: ArrayLike
-) -> tuple[str, ArrayLike]:
-    """Helper function to find mesh location where array is defined"""
-
-    dimension_to_location = {
-        "nCells": "cell",
-        "nEdges": "edge",
-        "nVertices": "vertex",
-    }
-
-    if array.ndim != 1:
-        msg = f"Array should be one dimensional, instead has {array.ndim} dims"
-        if sum([size > 1 for size in array.shape]) > 1:
-            # more than one dimensions is greater than length one
-            raise ValueError(msg)
-        array = array.squeeze()
-
-    # dict of dim lengths of the original dataset
-    origin_rev = {v: k for k, v in descriptor.sizes.items()}
-    # dict of dim lengths of the culled dataset
-    culled_rev = {descriptor.ds.sizes[d]: d for d in descriptor.sizes}
-
-    # start by trying to find match in original dataset
-    dim = origin_rev.get(array.size)
-    if dim is not None:
-        loc = dimension_to_location[dim]
-        array_name = f"indexTo{loc.capitalize()}ID"
-        if array_name in descriptor.ds:
-            lut = descriptor.ds[array_name]
-            return loc, array[lut]
-        return loc, array
-
-    # fallback to checking culled dataset
-    dim = culled_rev.get(array.size)
-    if dim is not None:
-        # no need to look up table with culled mesh array
-        return dimension_to_location[dim], array
-
-    msg = (
-        f"Size of array {array.size} is incompatible with mesh dimensions "
-        f"{descriptor.sizes}"
-    )
-    raise ValueError(msg)
-
-
-def _parse_args(
-    descriptor: Descriptor, array: ArrayLike
-) -> tuple[ArrayLike, ArrayLike]:
-    """Helper function to get patch array corresponding to dataarray"""
-
-    loc, array = _get_array_location(descriptor, array)
-
-    verts = getattr(descriptor, f"{loc}_patches")
-
-    return verts, array
 
 
 def _mirror_polycollection(ax, collection, descriptor, array, **kwargs):
@@ -75,7 +16,7 @@ def _mirror_polycollection(ax, collection, descriptor, array, **kwargs):
     Following ``cartopy.mpl.geoaxes._wrap_quadmesh``
     """
 
-    loc, array = _get_array_location(descriptor, array)
+    loc, array = descriptor._get_array_location(array)
 
     mirrored_verts = getattr(descriptor, f"_{loc}_mirrored", None)
     mirrored_idxs = getattr(descriptor, f"_{loc}_mirrored_idxs", None)
@@ -148,7 +89,8 @@ def polypcolor(
         :py:class:`~matplotlib.collections.PolyCollection` creation.
     """
 
-    verts, array = _parse_args(descriptor, array)
+    loc, array = descriptor._get_array_location(array)
+    verts = getattr(descriptor, f"{loc}_patches")
 
     # need to pop b/c PolyCollection does not accept these
     vmin = kwargs.pop("vmin", None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "h5netcdf",
     "netcdf4",
     "matplotlib",
+    "networkx",
     "numpy",
     "pooch",
     "pyproj",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ dependencies = [
     "h5netcdf",
     "netcdf4",
     "matplotlib",
-    "networkx",
     "numpy",
     "pooch",
     "pyproj",
@@ -52,6 +51,7 @@ dev = [
     "isort",
     "flake8",
     "mypy",
+    "networkx",
     "pre-commit",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dev = [
     "isort",
     "flake8",
     "mypy",
+    "hypothesis",
     "networkx",
     "pre-commit",
 ]

--- a/tests/test_contour.py
+++ b/tests/test_contour.py
@@ -151,3 +151,62 @@ class TestUnfilledContourGraphProperties(ContourGraphGenerator):
                 if len(invalid) > 0:
                     msg = f"Endpoints {invalid} are not boundary vertices."
                     raise AssertionError(msg)
+
+
+class TestEmptyContours:
+    ds = mosaic.datasets.open_dataset("QU.240km")
+    descriptor = mosaic.Descriptor(ds, projection=ccrs.PlateCarree())
+
+    def test_unfilled_contour_all_below_level(self) -> None:
+        """When all values are below contour level, return empty contour"""
+        field = np.ones(self.descriptor.sizes["nCells"]) * 5.0
+        level = 10.0
+
+        contour_gen = MPASContourGenerator(self.descriptor, field)
+        polys, codes = contour_gen.create_contour(level)
+
+        assert isinstance(polys, list)
+        assert isinstance(codes, list)
+        assert len(polys) == 0
+        assert len(codes) == 0
+
+    def test_unfilled_contour_all_above_level(self) -> None:
+        """When all values are above contour level, return empty contour"""
+        field = np.ones(self.descriptor.sizes["nCells"]) * 10.0
+        level = 5.0
+
+        contour_gen = MPASContourGenerator(self.descriptor, field)
+        polys, codes = contour_gen.create_contour(level)
+
+        assert isinstance(polys, list)
+        assert isinstance(codes, list)
+        assert len(polys) == 0
+        assert len(codes) == 0
+
+    def test_filled_contour_levels_all_above(self) -> None:
+        """When field is outside fill bounds, return empty contour"""
+        field = np.ones(self.descriptor.sizes["nCells"]) * 5.0
+
+        contour_gen = MPASContourGenerator(self.descriptor, field)
+        polys, codes = contour_gen.create_filled_contour(
+            lower_level=10.0, upper_level=20.0
+        )
+
+        assert isinstance(polys, list)
+        assert isinstance(codes, list)
+        assert len(polys) == 0
+        assert len(codes) == 0
+
+    def test_filled_contour_levels_all_below(self) -> None:
+        """When field is outside fill bounds, return empty contour"""
+        field = np.ones(self.descriptor.sizes["nCells"]) * 20.0
+
+        contour_gen = MPASContourGenerator(self.descriptor, field)
+        polys, codes = contour_gen.create_filled_contour(
+            lower_level=5.0, upper_level=10.0
+        )
+
+        assert isinstance(polys, list)
+        assert isinstance(codes, list)
+        assert len(polys) == 0
+        assert len(codes) == 0

--- a/tests/test_contour.py
+++ b/tests/test_contour.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import cartopy.crs as ccrs
+import networkx as nx
+import numpy as np
+from hypothesis import assume, given, settings
+from hypothesis import strategies as st
+from hypothesis.extra import numpy as hnp
+
+import mosaic
+from mosaic.contour import MPASContourGenerator
+
+
+class ContourCycleGraphGenerator:
+    """ """
+
+    ds = mosaic.datasets.open_dataset("QU.240km")
+    descriptor = mosaic.Descriptor(ds, projection=ccrs.PlateCarree())
+
+    def _build_contour_cyle_graph(
+        self, data: st.DataObject, filled: bool
+    ) -> tuple[nx.Graph, set[int]]:
+        """ """
+
+        n_cells = self.descriptor.sizes["nCells"]
+
+        field = data.draw(
+            hnp.arrays(
+                dtype=float,
+                shape=(n_cells,),
+                elements=st.floats(
+                    min_value=-1e6,
+                    max_value=+1e6,
+                    allow_nan=False,
+                    allow_infinity=False,
+                ),
+            )
+        )
+
+        field_min, field_max = np.min(field), np.max(field)
+
+        # Ensure field has sufficient variation
+        assume(field_min < field_max)
+        # TODO: Adjust this threshold based on range of values in field
+        assume(field_max - field_min > 1.0)
+
+        if filled:
+            # Generate contour levels strictly between min and max
+            lower_level = data.draw(
+                st.floats(
+                    min_value=field_min,
+                    max_value=field_max,
+                    exclude_min=True,
+                    exclude_max=True,
+                )
+            )
+
+            upper_level = data.draw(
+                st.floats(
+                    min_value=lower_level,
+                    max_value=field_max,
+                    exclude_max=True,
+                )
+            )
+            # Ensure lower < upper
+            assume(lower_level < upper_level)
+
+            cell_mask = (field > lower_level) & (field < upper_level)
+        else:
+            # Generate contour level strictly between min and max
+            level = data.draw(
+                st.floats(
+                    min_value=field_min,
+                    max_value=field_max,
+                    exclude_min=True,
+                    exclude_max=True,
+                    allow_nan=False,
+                    allow_infinity=False,
+                )
+            )
+
+            cell_mask = field > level
+
+        # Exclude all True and all False masks
+        assume(cell_mask.any() and (~cell_mask).any())
+
+        contour_gen = MPASContourGenerator(
+            self.descriptor, cell_mask.astype(float)
+        )
+
+        graph = contour_gen._create_contour_graph(cell_mask, filled=filled)
+        boundary_vertices = set(contour_gen.boundary_vertices)
+
+        return graph, boundary_vertices
+
+
+class TestFilledContourProperties(ContourCycleGraphGenerator):
+    """ """
+
+    @settings(deadline=None, max_examples=200)
+    @given(data=st.data())
+    def test_node_degrees_are_2(self, data: st.DataObject) -> None:
+        """Test that all nodes in the boundary graph have degree 1 or 2."""
+        graph, _ = self._build_contour_cyle_graph(data, filled=True)
+
+        for node, degree in graph.degree():
+            assert degree == 2, (
+                f"Node {node} has degree {degree}; expected 1 or 2."
+            )
+
+
+class TestUnfilledContourProperties(ContourCycleGraphGenerator):
+    """ """
+
+    @settings(deadline=None, max_examples=200)
+    @given(data=st.data())
+    def test_node_degrees_are_1_or_2(self, data: st.DataObject) -> None:
+        """Test that all nodes in the boundary graph have degree 1 or 2."""
+        graph, _ = self._build_contour_cyle_graph(data, filled=False)
+
+        for node, degree in graph.degree():
+            assert degree in (1, 2), (
+                f"Node {node} has degree {degree}; expected 1 or 2."
+            )
+
+    @settings(deadline=None, max_examples=200)
+    @given(data=st.data())
+    def test_paths_endpoints_on_boundary(self, data: st.DataObject) -> None:
+        """ """
+        graph, boundary_vertices = self._build_contour_cyle_graph(
+            data, filled=False
+        )
+
+        for component in nx.connected_components(graph):
+            subgraph = graph.subgraph(component)
+            endpoints = [n for n, d in subgraph.degree() if d == 1]
+
+            if len(endpoints) != 0:
+                invalid = set(endpoints) - boundary_vertices
+
+                if len(invalid) > 0:
+                    msg = f"Endpoints {invalid} are not boundary vertices."
+                    raise AssertionError(msg)

--- a/tests/test_contour.py
+++ b/tests/test_contour.py
@@ -11,8 +11,10 @@ import mosaic
 from mosaic.contour import MPASContourGenerator
 
 
-class ContourCycleGraphGenerator:
-    """ """
+class ContourGraphGenerator:
+    """
+    Generate random field of floats and random contour (filled or unfilled)
+    """
 
     ds = mosaic.datasets.open_dataset("QU.240km")
     descriptor = mosaic.Descriptor(ds, projection=ccrs.PlateCarree())
@@ -20,8 +22,6 @@ class ContourCycleGraphGenerator:
     def _build_contour_cyle_graph(
         self, data: st.DataObject, filled: bool
     ) -> tuple[nx.Graph, set[int]]:
-        """ """
-
         n_cells = self.descriptor.sizes["nCells"]
 
         field = data.draw(
@@ -38,14 +38,16 @@ class ContourCycleGraphGenerator:
         )
 
         field_min, field_max = np.min(field), np.max(field)
+        field_range = field_max - field_min
 
         # Ensure field has sufficient variation
         assume(field_min < field_max)
-        # TODO: Adjust this threshold based on range of values in field
-        assume(field_max - field_min > 1.0)
+        # Ensure at least 1% relative variation, or absolute minimum of 0.01
+        min_variation = max(0.01, 0.01 * abs(field_max))
+        assume(field_range > min_variation)
 
+        # Generate contour levels strictly between min and max
         if filled:
-            # Generate contour levels strictly between min and max
             lower_level = data.draw(
                 st.floats(
                     min_value=field_min,
@@ -67,7 +69,6 @@ class ContourCycleGraphGenerator:
 
             cell_mask = (field > lower_level) & (field < upper_level)
         else:
-            # Generate contour level strictly between min and max
             level = data.draw(
                 st.floats(
                     min_value=field_min,
@@ -94,13 +95,17 @@ class ContourCycleGraphGenerator:
         return graph, boundary_vertices
 
 
-class TestFilledContourProperties(ContourCycleGraphGenerator):
-    """ """
+class TestFilledContourGraphProperties(ContourGraphGenerator):
+    """
+    Filled contours should only be cycle graphs
+
+    .. [1] https://en.wikipedia.org/wiki/Cycle_graph
+    """
 
     @settings(deadline=None, max_examples=200)
     @given(data=st.data())
     def test_node_degrees_are_2(self, data: st.DataObject) -> None:
-        """Test that all nodes in the boundary graph have degree 1 or 2."""
+        """Cycle graphs should only have nodes of degree 2"""
         graph, _ = self._build_contour_cyle_graph(data, filled=True)
 
         for node, degree in graph.degree():
@@ -109,13 +114,18 @@ class TestFilledContourProperties(ContourCycleGraphGenerator):
             )
 
 
-class TestUnfilledContourProperties(ContourCycleGraphGenerator):
-    """ """
+class TestUnfilledContourGraphProperties(ContourGraphGenerator):
+    """
+    Unfilled contours should only be path or cycle graphs
+
+    .. [1] https://en.wikipedia.org/wiki/Path_graph
+    .. [2] https://en.wikipedia.org/wiki/Cycle_graph
+    """
 
     @settings(deadline=None, max_examples=200)
     @given(data=st.data())
     def test_node_degrees_are_1_or_2(self, data: st.DataObject) -> None:
-        """Test that all nodes in the boundary graph have degree 1 or 2."""
+        """Path/cycle graphs should only have nodes of deg. 1/2, respctively"""
         graph, _ = self._build_contour_cyle_graph(data, filled=False)
 
         for node, degree in graph.degree():
@@ -125,8 +135,8 @@ class TestUnfilledContourProperties(ContourCycleGraphGenerator):
 
     @settings(deadline=None, max_examples=200)
     @given(data=st.data())
-    def test_paths_endpoints_on_boundary(self, data: st.DataObject) -> None:
-        """ """
+    def test_path_endpoints_on_boundary(self, data: st.DataObject) -> None:
+        """If component is path graph, should begin & end on mesh boundary"""
         graph, boundary_vertices = self._build_contour_cyle_graph(
             data, filled=False
         )

--- a/tests/test_contour.py
+++ b/tests/test_contour.py
@@ -142,7 +142,7 @@ class ContourGraphGenerator(ContourGenerator):
     Also returns unique boundary vertices, needed for proppert testing
     """
 
-    def _build_contour_cyle_graph(
+    def _build_contour_cycle_graph(
         self, data: st.DataObject, filled: bool
     ) -> tuple[nx.Graph, set[int]]:
         field = self._build_field(data)
@@ -238,7 +238,7 @@ class TestFilledContourGraphProperties(ContourGraphGenerator):
     @given(data=st.data())
     def test_node_degrees_are_2(self, data: st.DataObject) -> None:
         """Cycle graphs should only have nodes of degree 2"""
-        graph, _ = self._build_contour_cyle_graph(data, filled=True)
+        graph, _ = self._build_contour_cycle_graph(data, filled=True)
 
         for node, degree in graph.degree():
             assert degree == 2, (
@@ -258,7 +258,7 @@ class TestUnfilledContourGraphProperties(ContourGraphGenerator):
     @given(data=st.data())
     def test_node_degrees_are_1_or_2(self, data: st.DataObject) -> None:
         """Path/cycle graphs should only have nodes of deg. 1/2, respctively"""
-        graph, _ = self._build_contour_cyle_graph(data, filled=False)
+        graph, _ = self._build_contour_cycle_graph(data, filled=False)
 
         for node, degree in graph.degree():
             assert degree in (1, 2), (
@@ -269,7 +269,7 @@ class TestUnfilledContourGraphProperties(ContourGraphGenerator):
     @given(data=st.data())
     def test_path_endpoints_on_boundary(self, data: st.DataObject) -> None:
         """If component is path graph, should begin & end on mesh boundary"""
-        graph, boundary_vertices = self._build_contour_cyle_graph(
+        graph, boundary_vertices = self._build_contour_cycle_graph(
             data, filled=False
         )
 

--- a/tests/test_contour.py
+++ b/tests/test_contour.py
@@ -11,7 +11,54 @@ from hypothesis.extra import numpy as hnp
 from shapely import LineString, Polygon
 
 import mosaic
-from mosaic.contour import MPASContourGenerator
+from mosaic.contour import MPASContourGenerator, _is_ccw
+
+# TODO:
+# - [ ] Need some further investigation of how matplotlib handles nans
+
+
+def _square_ring(
+    cx: float, cy: float, size: float, ccw: bool = True
+) -> np.ndarray:
+    """Return a closed square ring centered at (cx, cy) with half-width *size*.
+
+    The ring is counter-clockwise by default and clockwise when ccw=False.
+    """
+    if ccw:
+        coords = [
+            [cx - size, cy - size],
+            [cx + size, cy - size],
+            [cx + size, cy + size],
+            [cx - size, cy + size],
+        ]
+    else:
+        coords = [
+            [cx - size, cy - size],
+            [cx - size, cy + size],
+            [cx + size, cy + size],
+            [cx + size, cy - size],
+        ]
+    coords.append(coords[0])
+    return np.array(coords, dtype=float)
+
+
+def _make_codes(ring: np.ndarray) -> np.ndarray:
+    """Return matplotlib path codes for a single ring (MOVETO + LINETOs)."""
+    codes = np.full(len(ring), mpath.Path.LINETO, dtype=mpath.Path.code_type)
+    codes[0] = mpath.Path.MOVETO
+    return codes
+
+
+def _parse_rings(
+    poly_coords: np.ndarray, codes: np.ndarray
+) -> list[np.ndarray]:
+    """Split a single output path into constituent rings by MOVETO boundary."""
+    starts = np.flatnonzero(codes == mpath.Path.MOVETO)
+    rings = []
+    for i, start in enumerate(starts):
+        end = starts[i + 1] if i + 1 < len(starts) else len(codes)
+        rings.append(poly_coords[start:end])
+    return rings
 
 
 class ContourGenerator:
@@ -365,3 +412,159 @@ class TestCheckLevels:
             self.contour_gen.check_levels(
                 lower_level=lower_level, upper_level=upper_level
             )
+
+
+class TestSortFilledContoursUnit:
+    """Unit tests for _sort_filled_contours using synthetic ring data.
+
+    Each test constructs explicit coordinate arrays at known nesting depths
+    and checks that the output topology (number of paths, ring counts, hole
+    containment, and winding order) matches the expected result.
+    """
+
+    ds = mosaic.datasets.open_dataset("QU.240km")
+    descriptor = mosaic.Descriptor(ds, projection=ccrs.PlateCarree())
+    field = np.ones(descriptor.sizes["nCells"])
+    contour_gen = MPASContourGenerator(descriptor, field)
+
+    def test_single_ring_no_holes(self) -> None:
+        """A single ring with no nesting produces one exterior polygon."""
+        ring = _square_ring(0, 0, 5)
+        polys = [ring]
+        codes = [_make_codes(ring)]
+
+        out_polys, out_codes = self.contour_gen._sort_filled_contours(
+            polys, codes
+        )
+
+        assert len(out_polys) == 1
+        assert np.sum(out_codes[0] == mpath.Path.MOVETO) == 1
+
+    def test_two_disjoint_rings(self) -> None:
+        """Two non-overlapping rings produce two separate exterior polygons."""
+        polys = [_square_ring(0, 0, 5), _square_ring(20, 0, 5)]
+        codes = [_make_codes(r) for r in polys]
+
+        out_polys, out_codes = self.contour_gen._sort_filled_contours(
+            polys, codes
+        )
+
+        assert len(out_polys) == 2
+        assert all(np.sum(c == mpath.Path.MOVETO) == 1 for c in out_codes)
+
+    def test_simple_donut(self) -> None:
+        """One ring containing another produces one polygon with one hole."""
+        outer = _square_ring(0, 0, 10)
+        inner = _square_ring(0, 0, 4)
+        polys = [outer, inner]
+        codes = [_make_codes(r) for r in polys]
+
+        out_polys, out_codes = self.contour_gen._sort_filled_contours(
+            polys, codes
+        )
+
+        assert len(out_polys) == 1
+        rings = _parse_rings(out_polys[0], out_codes[0])
+        assert len(rings) == 2
+
+    def test_three_level_nesting(self) -> None:
+        """A→B→C nesting: exterior A with hole B, and standalone exterior C."""
+        ring_a = _square_ring(0, 0, 12)
+        ring_b = _square_ring(0, 0, 8)
+        ring_c = _square_ring(0, 0, 4)
+        polys = [ring_a, ring_b, ring_c]
+        codes = [_make_codes(r) for r in polys]
+
+        out_polys, out_codes = self.contour_gen._sort_filled_contours(
+            polys, codes
+        )
+
+        assert len(out_polys) == 2
+        moveto_counts = sorted(
+            np.sum(c == mpath.Path.MOVETO) for c in out_codes
+        )
+        assert moveto_counts == [1, 2]
+
+    def test_multiple_holes(self) -> None:
+        """One exterior ring containing three disjoint holes."""
+        polys = [
+            _square_ring(0, 0, 20),
+            _square_ring(-10, 0, 3),
+            _square_ring(0, 0, 3),
+            _square_ring(10, 0, 3),
+        ]
+        codes = [_make_codes(r) for r in polys]
+
+        out_polys, out_codes = self.contour_gen._sort_filled_contours(
+            polys, codes
+        )
+
+        assert len(out_polys) == 1
+        assert np.sum(out_codes[0] == mpath.Path.MOVETO) == 4
+
+    def test_two_separate_donuts(self) -> None:
+        """Two independent donuts each produce one polygon with one hole."""
+        polys = [
+            _square_ring(-15, 0, 8),
+            _square_ring(-15, 0, 3),
+            _square_ring(15, 0, 8),
+            _square_ring(15, 0, 3),
+        ]
+        codes = [_make_codes(r) for r in polys]
+
+        out_polys, out_codes = self.contour_gen._sort_filled_contours(
+            polys, codes
+        )
+
+        assert len(out_polys) == 2
+        assert all(np.sum(c == mpath.Path.MOVETO) == 2 for c in out_codes)
+
+    def test_deep_nesting_four_levels(self) -> None:
+        """A→B→C→D: two output polygons, each with one hole."""
+        polys = [
+            _square_ring(0, 0, 16),
+            _square_ring(0, 0, 12),
+            _square_ring(0, 0, 8),
+            _square_ring(0, 0, 4),
+        ]
+        codes = [_make_codes(r) for r in polys]
+
+        out_polys, out_codes = self.contour_gen._sort_filled_contours(
+            polys, codes
+        )
+
+        assert len(out_polys) == 2
+        moveto_counts = sorted(
+            np.sum(c == mpath.Path.MOVETO) for c in out_codes
+        )
+        assert moveto_counts == [2, 2]
+
+    def test_winding_order_correction_same_orientation(self) -> None:
+        """A hole with the same winding as its exterior must be reversed."""
+        outer = _square_ring(0, 0, 10, ccw=True)
+        inner = _square_ring(0, 0, 4, ccw=True)
+        polys = [outer, inner]
+        codes = [_make_codes(r) for r in polys]
+
+        out_polys, out_codes = self.contour_gen._sort_filled_contours(
+            polys, codes
+        )
+
+        rings = _parse_rings(out_polys[0], out_codes[0])
+        assert _is_ccw(Polygon(rings[0]))
+        assert not _is_ccw(Polygon(rings[1]))
+
+    def test_hole_already_opposite_winding(self) -> None:
+        """A hole already opposite to its exterior must not be reversed."""
+        outer = _square_ring(0, 0, 10, ccw=True)
+        inner = _square_ring(0, 0, 4, ccw=False)
+        polys = [outer, inner]
+        codes = [_make_codes(r) for r in polys]
+
+        out_polys, out_codes = self.contour_gen._sort_filled_contours(
+            polys, codes
+        )
+
+        rings = _parse_rings(out_polys[0], out_codes[0])
+        assert _is_ccw(Polygon(rings[0]))
+        assert not _is_ccw(Polygon(rings[1]))

--- a/tests/test_contour.py
+++ b/tests/test_contour.py
@@ -1,18 +1,20 @@
 from __future__ import annotations
 
 import cartopy.crs as ccrs
+import matplotlib.path as mpath
 import networkx as nx
 import numpy as np
 import pytest
 from hypothesis import assume, given, settings
 from hypothesis import strategies as st
 from hypothesis.extra import numpy as hnp
+from shapely import LineString, Polygon
 
 import mosaic
 from mosaic.contour import MPASContourGenerator
 
 
-class ContourGraphGenerator:
+class ContourGenerator:
     """
     Generate random field of floats and random contour (filled or unfilled)
     """
@@ -20,9 +22,7 @@ class ContourGraphGenerator:
     ds = mosaic.datasets.open_dataset("QU.240km")
     descriptor = mosaic.Descriptor(ds, projection=ccrs.PlateCarree())
 
-    def _build_contour_cyle_graph(
-        self, data: st.DataObject, filled: bool
-    ) -> tuple[nx.Graph, set[int]]:
+    def _build_field(self, data: st.DataObject) -> np.ndarray:
         n_cells = self.descriptor.sizes["nCells"]
 
         field = data.draw(
@@ -47,38 +47,72 @@ class ContourGraphGenerator:
         min_variation = max(0.01, 0.01 * abs(field_max))
         assume(field_range > min_variation)
 
-        # Generate contour levels strictly between min and max
-        if filled:
-            lower_level = data.draw(
-                st.floats(
-                    min_value=field_min,
-                    max_value=field_max,
-                    exclude_min=True,
-                    exclude_max=True,
-                )
-            )
+        return field
 
-            upper_level = data.draw(
-                st.floats(
-                    min_value=lower_level,
-                    max_value=field_max,
-                    exclude_max=True,
-                )
+    def _build_unfilled_contour_level(
+        self, field_min: float, field_max: float, data: st.DataObject
+    ) -> float:
+        return data.draw(
+            st.floats(
+                min_value=field_min,
+                max_value=field_max,
+                exclude_min=True,
+                exclude_max=True,
+                allow_nan=False,
+                allow_infinity=False,
             )
-            # Ensure lower < upper
-            assume(lower_level < upper_level)
+        )
+
+    def _build_filled_contour_levels(
+        self, field_min: float, field_max: float, data: st.DataObject
+    ) -> tuple[float, float]:
+        lower_level = data.draw(
+            st.floats(
+                min_value=field_min,
+                max_value=field_max,
+                exclude_min=True,
+                exclude_max=True,
+            )
+        )
+
+        upper_level = data.draw(
+            st.floats(
+                min_value=lower_level,
+                max_value=field_max,
+                exclude_max=True,
+            )
+        )
+        # Ensure lower < upper
+        assume(lower_level < upper_level)
+
+        return lower_level, upper_level
+
+
+class ContourGraphGenerator(ContourGenerator):
+    """
+    Convert random field and contour to a networkx.Graph
+
+    Also returns unique boundary vertices, needed for proppert testing
+    """
+
+    def _build_contour_cyle_graph(
+        self, data: st.DataObject, filled: bool
+    ) -> tuple[nx.Graph, set[int]]:
+        field = self._build_field(data)
+
+        field_min, field_max = np.min(field), np.max(field)
+
+        contour_gen = MPASContourGenerator(self.descriptor, field)
+
+        if filled:
+            lower_level, upper_level = self._build_filled_contour_levels(
+                field_min=field_min, field_max=field_max, data=data
+            )
 
             cell_mask = (field > lower_level) & (field < upper_level)
         else:
-            level = data.draw(
-                st.floats(
-                    min_value=field_min,
-                    max_value=field_max,
-                    exclude_min=True,
-                    exclude_max=True,
-                    allow_nan=False,
-                    allow_infinity=False,
-                )
+            level = self._build_unfilled_contour_level(
+                field_min=field_min, field_max=field_max, data=data
             )
 
             cell_mask = field > level
@@ -86,14 +120,64 @@ class ContourGraphGenerator:
         # Exclude all True and all False masks
         assume(cell_mask.any() and (~cell_mask).any())
 
-        contour_gen = MPASContourGenerator(
-            self.descriptor, cell_mask.astype(float)
-        )
-
         graph = contour_gen._create_contour_graph(cell_mask, filled=filled)
         boundary_vertices = set(contour_gen.boundary_vertices)
 
         return graph, boundary_vertices
+
+
+class ContourGeometryGenerator(ContourGenerator):
+    """
+    Convert contour coordinates to Shapely geometries
+
+    Filled contour --> shapely.Polygon
+    Unfilled Conoutr --> shapely.LineString
+    """
+
+    def _build_contour_geometries(
+        self, data: st.DataObject, filled: bool
+    ) -> list[LineString] | list[Polygon]:
+        field = self._build_field(data)
+
+        field_min, field_max = np.min(field), np.max(field)
+
+        contour_gen = MPASContourGenerator(self.descriptor, field)
+
+        if filled:
+            lower_level, upper_level = self._build_filled_contour_levels(
+                field_min=field_min, field_max=field_max, data=data
+            )
+
+            polys, codes = contour_gen.create_filled_contour(
+                lower_level, upper_level
+            )
+
+            geoms = []
+            for p, c in zip(polys, codes, strict=True):
+                # Split at MOVETO boundaries
+                starts = np.flatnonzero(c == mpath.Path.MOVETO)
+                # first ring = exterior shell, rest = holes
+                rings = [
+                    p[
+                        starts[i] : starts[i + 1]
+                        if i + 1 < len(starts)
+                        else len(p)
+                    ]
+                    for i in range(len(starts))
+                ]
+
+                geoms.append(Polygon(shell=rings[0], holes=rings[1:]))
+
+        else:
+            level = self._build_unfilled_contour_level(
+                field_min=field_min, field_max=field_max, data=data
+            )
+
+            polys, _ = contour_gen.create_contour(level)
+
+            geoms = [LineString(p) for p in polys]
+
+        return geoms
 
 
 class TestFilledContourGraphProperties(ContourGraphGenerator):
@@ -154,7 +238,35 @@ class TestUnfilledContourGraphProperties(ContourGraphGenerator):
                     raise AssertionError(msg)
 
 
+class TestFilledContourPolygonProperties(ContourGeometryGenerator):
+    """Cycle graphs produced by a filled contour should be valid Polygons"""
+
+    @settings(deadline=None, max_examples=200)
+    @given(data=st.data())
+    def test_no_self_intersection_and_closed(
+        self, data: st.DataObject
+    ) -> None:
+        """Polygon is valid if closed and is not self intersecting"""
+        geoms = self._build_contour_geometries(data, filled=True)
+
+        assert all(g.is_valid for g in geoms)
+
+
+class TestUnfilledContourLineStringProperties(ContourGeometryGenerator):
+    """Convert unfilled contours to LineStrings; test for self intersection"""
+
+    @settings(deadline=None, max_examples=200)
+    @given(data=st.data())
+    def test_no_self_intersection(self, data: st.DataObject) -> None:
+        """LineStrings is simple if there is no self intersection"""
+        geoms = self._build_contour_geometries(data, filled=False)
+
+        assert all(g.is_simple for g in geoms)
+
+
 class TestEmptyContours:
+    """Test empty contour is well defined"""
+
     ds = mosaic.datasets.open_dataset("QU.240km")
     descriptor = mosaic.Descriptor(ds, projection=ccrs.PlateCarree())
 

--- a/tests/test_contour.py
+++ b/tests/test_contour.py
@@ -123,7 +123,7 @@ class ContourGraphGenerator(ContourGenerator):
         graph = contour_gen._create_contour_graph(cell_mask, filled=filled)
         boundary_vertices = set(contour_gen.boundary_vertices)
 
-        return graph, boundary_vertices
+        return graph.to_networkx(), boundary_vertices
 
 
 class ContourGeometryGenerator(ContourGenerator):

--- a/tests/test_contour.py
+++ b/tests/test_contour.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import cartopy.crs as ccrs
 import networkx as nx
 import numpy as np
+import pytest
 from hypothesis import assume, given, settings
 from hypothesis import strategies as st
 from hypothesis.extra import numpy as hnp
@@ -210,3 +211,45 @@ class TestEmptyContours:
         assert isinstance(codes, list)
         assert len(polys) == 0
         assert len(codes) == 0
+
+
+class TestCheckLevels:
+    """Test validation of contour level ordering"""
+
+    ds = mosaic.datasets.open_dataset("QU.240km")
+    descriptor = mosaic.Descriptor(ds, projection=ccrs.PlateCarree())
+    field = np.ones(descriptor.sizes["nCells"])
+    contour_gen = MPASContourGenerator(descriptor, field)
+
+    def test_check_levels_valid_increasing(self) -> None:
+        """Contour levels with lower < upper should pass validation"""
+        lower_level = 5.0
+        upper_level = 10.0
+
+        result_lower, result_upper = self.contour_gen.check_levels(
+            lower_level, upper_level
+        )
+
+        assert result_upper == upper_level
+        assert result_lower == lower_level
+
+    def test_check_levels_equal(self) -> None:
+        """Contour levels with lower == upper should raise ValueError"""
+        level = 5.0
+
+        with pytest.raises(
+            ValueError, match="Contour levels must be increasing"
+        ):
+            self.contour_gen.check_levels(lower_level=level, upper_level=level)
+
+    def test_check_levels_inverted(self) -> None:
+        """Contour levels with lower > upper should raise ValueError"""
+        lower_level = 10.0
+        upper_level = 5.0
+
+        with pytest.raises(
+            ValueError, match="Contour levels must be increasing"
+        ):
+            self.contour_gen.check_levels(
+                lower_level=lower_level, upper_level=upper_level
+            )

--- a/tests/test_contour_graph.py
+++ b/tests/test_contour_graph.py
@@ -1,0 +1,411 @@
+from __future__ import annotations
+
+import sys
+from itertools import pairwise
+
+import networkx as nx
+import numpy as np
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from mosaic.contour import ContourGraph
+
+# ---------------------------------------------------------------------------
+# Hypothesis strategies for structured graph inputs
+# ---------------------------------------------------------------------------
+
+
+@st.composite
+def path_graph(draw) -> tuple[ContourGraph, list[int]]:
+    """Draw a single path graph: n unique nodes connected in a line."""
+    nodes = draw(
+        st.lists(
+            st.integers(min_value=0, max_value=10_000), min_size=2, unique=True
+        )
+    )
+    v1 = np.array(nodes[:-1])
+    v2 = np.array(nodes[1:])
+    return ContourGraph(v1, v2), nodes
+
+
+@st.composite
+def cycle_graph(draw) -> tuple[ContourGraph, list[int]]:
+    """Draw a single cycle graph: n unique nodes connected in a closed loop."""
+    nodes = draw(
+        st.lists(
+            st.integers(min_value=0, max_value=10_000), min_size=3, unique=True
+        )
+    )
+    v1 = np.array(nodes)
+    v2 = np.roll(v1, -1)
+    return ContourGraph(v1, v2), nodes
+
+
+@st.composite
+def multi_component_graph(draw) -> tuple[ContourGraph, list[list[int]]]:
+    """Draw 1-4 independent path or cycle components with disjoint node IDs."""
+    n_components = draw(st.integers(min_value=1, max_value=4))
+
+    all_v1, all_v2 = [], []
+    components = []
+    used: set[int] = set()
+
+    for _ in range(n_components):
+        size = draw(st.integers(min_value=2, max_value=20))
+        is_cycle = draw(st.booleans())
+
+        # Draw node IDs that don't collide with previously used ones
+        nodes = draw(
+            st.lists(
+                st.integers(min_value=0, max_value=100_000).filter(
+                    lambda x: x not in used
+                ),
+                min_size=max(size, 3 if is_cycle else 2),
+                max_size=max(size, 3 if is_cycle else 2),
+                unique=True,
+            )
+        )
+        used.update(nodes)
+        components.append(nodes)
+
+        if is_cycle:
+            v1 = np.array(nodes)
+            v2 = np.roll(v1, -1)
+        else:
+            v1 = np.array(nodes[:-1])
+            v2 = np.array(nodes[1:])
+
+        all_v1.append(v1)
+        all_v2.append(v2)
+
+    g = ContourGraph(
+        np.concatenate(all_v1),
+        np.concatenate(all_v2),
+    )
+    return g, components
+
+
+# ---------------------------------------------------------------------------
+# Unit tests - construction
+# ---------------------------------------------------------------------------
+
+
+class TestConstruction:
+    def test_empty_graph_is_falsy(self) -> None:
+        g = ContourGraph(np.array([]), np.array([]))
+        assert not g
+
+    def test_nonempty_graph_is_truthy(self) -> None:
+        g = ContourGraph(np.array([0]), np.array([1]))
+        assert g
+
+    def test_single_edge_nodes(self) -> None:
+        g = ContourGraph(np.array([10]), np.array([20]))
+        assert set(g) == {10, 20}
+
+    def test_adjacency_is_symmetric(self) -> None:
+        # Path: 0 - 1 - 2
+        g = ContourGraph(np.array([0, 1]), np.array([1, 2]))
+        for u in g:
+            for v in g._adj[u]:
+                assert u in g._adj[v], f"{u} in adj[{v}] expected"
+
+    def test_node_set_equals_unique_vertices(self) -> None:
+        v1 = np.array([0, 1, 2])
+        v2 = np.array([1, 2, 3])
+        g = ContourGraph(v1, v2)
+        assert set(g) == {0, 1, 2, 3}
+
+
+# ---------------------------------------------------------------------------
+# Unit tests - degree
+# ---------------------------------------------------------------------------
+
+
+class TestDegree:
+    def test_path_endpoints_have_degree_1(self) -> None:
+        # Path: 0 - 1 - 2
+        g = ContourGraph(np.array([0, 1]), np.array([1, 2]))
+        assert g.degree(0) == 1
+        assert g.degree(2) == 1
+
+    def test_path_interior_has_degree_2(self) -> None:
+        # Path: 0 - 1 - 2
+        g = ContourGraph(np.array([0, 1]), np.array([1, 2]))
+        assert g.degree(1) == 2
+
+    def test_cycle_all_nodes_have_degree_2(self) -> None:
+        # Triangle: 0 - 1 - 2 - 0
+        g = ContourGraph(np.array([0, 1, 2]), np.array([1, 2, 0]))
+        for node in g:
+            assert g.degree(node) == 2
+
+
+# ---------------------------------------------------------------------------
+# Unit tests - components
+# ---------------------------------------------------------------------------
+
+
+class TestComponents:
+    def test_single_path_is_one_component(self) -> None:
+        # Path: 0 - 1 - 2 - 3
+        g = ContourGraph(np.array([0, 1, 2]), np.array([1, 2, 3]))
+        comps = list(g.components())
+        assert len(comps) == 1
+        assert comps[0] == {0, 1, 2, 3}
+
+    def test_single_cycle_is_one_component(self) -> None:
+        # Triangle: 0 - 1 - 2 - 0
+        g = ContourGraph(np.array([0, 1, 2]), np.array([1, 2, 0]))
+        comps = list(g.components())
+        assert len(comps) == 1
+        assert comps[0] == {0, 1, 2}
+
+    def test_two_disconnected_paths(self) -> None:
+        # Path A: 0-1-2  Path B: 10-11-12
+        g = ContourGraph(
+            np.array([0, 1, 10, 11]),
+            np.array([1, 2, 11, 12]),
+        )
+        comps = list(g.components())
+        assert len(comps) == 2
+        assert {0, 1, 2} in comps
+        assert {10, 11, 12} in comps
+
+    def test_components_are_disjoint(self) -> None:
+        g = ContourGraph(
+            np.array([0, 1, 10, 11]),
+            np.array([1, 2, 11, 12]),
+        )
+        comps = list(g.components())
+        all_nodes = [n for c in comps for n in c]
+        assert len(all_nodes) == len(set(all_nodes))
+
+    def test_components_cover_all_nodes(self) -> None:
+        g = ContourGraph(
+            np.array([0, 1, 10, 11]),
+            np.array([1, 2, 11, 12]),
+        )
+        assert {n for c in g.components() for n in c} == set(g)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests - walk
+# ---------------------------------------------------------------------------
+
+
+class TestWalk:
+    def test_walk_path_from_endpoint_visits_all_nodes(self) -> None:
+        # Path: 0 - 1 - 2 - 3
+        g = ContourGraph(np.array([0, 1, 2]), np.array([1, 2, 3]))
+        walked = g.walk(0)
+        assert set(walked) == {0, 1, 2, 3}
+
+    def test_walk_path_starts_at_given_node(self) -> None:
+        g = ContourGraph(np.array([0, 1, 2]), np.array([1, 2, 3]))
+        assert g.walk(0)[0] == 0
+        assert g.walk(3)[0] == 3
+
+    def test_walk_path_no_repeated_nodes(self) -> None:
+        g = ContourGraph(np.array([0, 1, 2]), np.array([1, 2, 3]))
+        walked = g.walk(0)
+        assert len(walked) == len(set(walked))
+
+    def test_walk_consecutive_nodes_are_adjacent(self) -> None:
+        g = ContourGraph(np.array([0, 1, 2]), np.array([1, 2, 3]))
+        walked = g.walk(0)
+        for a, b in pairwise(walked):
+            assert b in g._adj[a]
+
+    def test_walk_cycle_visits_all_nodes(self) -> None:
+        # Triangle: 0 - 1 - 2 - 0
+        g = ContourGraph(np.array([0, 1, 2]), np.array([1, 2, 0]))
+        walked = g.walk(0)
+        assert set(walked) == {0, 1, 2}
+
+    def test_walk_cycle_no_repeated_nodes(self) -> None:
+        g = ContourGraph(np.array([0, 1, 2]), np.array([1, 2, 0]))
+        walked = g.walk(0)
+        assert len(walked) == len(set(walked))
+
+
+# ---------------------------------------------------------------------------
+# Unit tests - to_networkx
+# ---------------------------------------------------------------------------
+
+
+class TestToNetworkx:
+    def test_node_sets_match(self) -> None:
+        g = ContourGraph(np.array([0, 1, 2]), np.array([1, 2, 0]))
+        nx_g = g.to_networkx()
+        assert set(nx_g.nodes()) == set(g)
+
+    def test_edge_sets_match(self) -> None:
+        g = ContourGraph(np.array([0, 1, 2]), np.array([1, 2, 0]))
+        nx_g = g.to_networkx()
+        expected_edges = {frozenset(e) for e in [(0, 1), (1, 2), (2, 0)]}
+        actual_edges = {frozenset(e) for e in nx_g.edges()}
+        assert actual_edges == expected_edges
+
+    def test_raises_import_error_when_networkx_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        g = ContourGraph(np.array([0, 1]), np.array([1, 2]))
+        monkeypatch.setitem(sys.modules, "networkx", None)
+        with pytest.raises(ImportError, match="networkx is required"):
+            g.to_networkx()
+
+
+# ---------------------------------------------------------------------------
+# Property tests - structural invariants
+# ---------------------------------------------------------------------------
+
+
+class TestPathGraphProperties:
+    @settings(deadline=None, max_examples=200)
+    @given(data=path_graph())
+    def test_adjacency_is_symmetric(
+        self, data: tuple[ContourGraph, list[int]]
+    ) -> None:
+        g, _ = data
+        for u in g:
+            for v in g._adj[u]:
+                assert u in g._adj[v]
+
+    @settings(deadline=None, max_examples=200)
+    @given(data=path_graph())
+    def test_endpoints_have_degree_1(
+        self, data: tuple[ContourGraph, list[int]]
+    ) -> None:
+        g, nodes = data
+        assert g.degree(nodes[0]) == 1
+        assert g.degree(nodes[-1]) == 1
+
+    @settings(deadline=None, max_examples=200)
+    @given(data=path_graph())
+    def test_interior_nodes_have_degree_2(
+        self, data: tuple[ContourGraph, list[int]]
+    ) -> None:
+        g, nodes = data
+        for node in nodes[1:-1]:
+            assert g.degree(node) == 2
+
+    @settings(deadline=None, max_examples=200)
+    @given(data=path_graph())
+    def test_walk_covers_all_nodes(
+        self, data: tuple[ContourGraph, list[int]]
+    ) -> None:
+        g, nodes = data
+        walked = g.walk(nodes[0])
+        assert set(walked) == set(nodes)
+
+    @settings(deadline=None, max_examples=200)
+    @given(data=path_graph())
+    def test_walk_length_equals_node_count(
+        self, data: tuple[ContourGraph, list[int]]
+    ) -> None:
+        g, nodes = data
+        assert len(g.walk(nodes[0])) == len(nodes)
+
+    @settings(deadline=None, max_examples=200)
+    @given(data=path_graph())
+    def test_walk_consecutive_nodes_are_adjacent(
+        self, data: tuple[ContourGraph, list[int]]
+    ) -> None:
+        g, nodes = data
+        walked = g.walk(nodes[0])
+        for a, b in pairwise(walked):
+            assert b in g._adj[a]
+
+
+class TestCycleGraphProperties:
+    @settings(deadline=None, max_examples=200)
+    @given(data=cycle_graph())
+    def test_all_nodes_have_degree_2(
+        self, data: tuple[ContourGraph, list[int]]
+    ) -> None:
+        g, _ = data
+        for node in g:
+            assert g.degree(node) == 2
+
+    @settings(deadline=None, max_examples=200)
+    @given(data=cycle_graph())
+    def test_walk_covers_all_nodes(
+        self, data: tuple[ContourGraph, list[int]]
+    ) -> None:
+        g, nodes = data
+        walked = g.walk(nodes[0])
+        assert set(walked) == set(nodes)
+
+    @settings(deadline=None, max_examples=200)
+    @given(data=cycle_graph())
+    def test_walk_no_repeated_nodes(
+        self, data: tuple[ContourGraph, list[int]]
+    ) -> None:
+        g, nodes = data
+        walked = g.walk(nodes[0])
+        assert len(walked) == len(set(walked))
+
+    @settings(deadline=None, max_examples=200)
+    @given(data=cycle_graph())
+    def test_walk_last_node_adjacent_to_first(
+        self, data: tuple[ContourGraph, list[int]]
+    ) -> None:
+        """The walk leaves off one step from closing the cycle."""
+        g, nodes = data
+        walked = g.walk(nodes[0])
+        assert walked[0] in g._adj[walked[-1]]
+
+
+# ---------------------------------------------------------------------------
+# Property tests - cross-validation against networkx
+# ---------------------------------------------------------------------------
+
+
+class TestAgainstNetworkx:
+    """Verify ContourGraph agrees with networkx on all relevant operations.
+
+    These tests are the primary argument for correctness: for randomly
+    generated graphs, ContourGraph and networkx must agree on components
+    and node degrees.
+    """
+
+    @settings(deadline=None, max_examples=200)
+    @given(data=multi_component_graph())
+    def test_components_match_networkx(
+        self, data: tuple[ContourGraph, list[list[int]]]
+    ) -> None:
+        g, _ = data
+        nx_comps = list(nx.connected_components(g.to_networkx()))
+
+        our_comps = list(g.components())
+
+        assert len(our_comps) == len(nx_comps)
+        assert sorted(our_comps, key=min) == sorted(nx_comps, key=min)
+
+    @settings(deadline=None, max_examples=200)
+    @given(data=multi_component_graph())
+    def test_degrees_match_networkx(
+        self, data: tuple[ContourGraph, list[list[int]]]
+    ) -> None:
+        g, _ = data
+        nx_g = g.to_networkx()
+
+        for node in g:
+            assert g.degree(node) == nx_g.degree(node)
+
+    @settings(deadline=None, max_examples=200)
+    @given(data=multi_component_graph())
+    def test_components_partition_node_set(
+        self, data: tuple[ContourGraph, list[list[int]]]
+    ) -> None:
+        g, _ = data
+        comps = list(g.components())
+
+        # disjoint
+        all_nodes = [n for c in comps for n in c]
+        assert len(all_nodes) == len(set(all_nodes))
+
+        # covers
+        assert set(all_nodes) == set(g)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -94,7 +94,9 @@ def test_util_vs_shapely_for_random_convex_polygon(scale):
         np.hstack([shapely.Polygon(p).centroid.xy for p in polys])
     )
 
-    np.testing.assert_allclose([cx, cy], [sx, sy], rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(
+        [cx, cy], [sx, sy], rtol=1e-10, atol=1e-10 * scale
+    )
 
 
 def test_padding_violation_raises_and_reports_cell():


### PR DESCRIPTION
## Native mesh contouring

This PR implements contouring on the native MPAS mesh, with the approach inspired by [`ridgepack`](https://github.com/proteanplanet/Ridgepack). The contours produced are "discrete", in that contours follow control volume boundaries (i.e. the contours of cell fields will lie along edges of mesh). This differs from a classical contouring (e.g. [marching squares](https://en.wikipedia.org/wiki/Marching_squares)), which expects data defined at discrete points (c.f. defined over a control volume) and general employs linear interpolation to produce smoothed contours. 

Contours of the unstructured mesh are treated as graphs. Because contours follow mesh boundaries, they should only ever be [path](https://en.wikipedia.org/wiki/Path_graph) or [cycle](https://en.wikipedia.org/wiki/Cycle_graph) graphs, which has no self intersections. We use [`hypothesis`](https://hypothesis.readthedocs.io/en/latest/index.html) for property based testing to confirm these invariants for randomly generated contour fields. 

For the end user, we follow the `matplotlib` [`contour`](https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.contour.html)/[`contourf`](https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.contourf.html) API as closely as possible, where `mosaic.contour`/`mosaic.contourf` require the matplotlib Axes and `mosiac.Descriptor` as positional arguments, but all keyword arguments are exactly the same.  In theory this also includes contour labeling, though more thorough testing is requite to validate this. We achieve this by sub-classing [`matplotlib.contour.ContourSet`](https://matplotlib.org/stable/api/contour_api.html#matplotlib.contour.ContourSet), which is the the data structure matplotlib uses to process/handle contours. 


**To Do**:
- [x] Docstrings for public functions. 
- [x] Update design doc with path / cycle graph observations. 
- [x] Example in documentation 
- [x] Test for containment / interior boundary properties
- [ ] ~Add support for vertex fields (?)~
  - Will be follow on PR
- [x] Drop `networkx` dependency and implement custom walk
- [ ] ~Coastlines (should this be a separate PR ?)~
  - Will be follow on PR