### PR TITLE
Drop latex rendering from design doc

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,17 +18,18 @@ def download_meshes(app, env, docnames):  # noqa: ARG001
         mosaic.datasets.open_dataset(mesh)
 
 
-def download_coastlines(app, env, docnames):  # noqa: ARG001
-    """Function to download coastlines prior to executing documentation, so
-    warnings don't appear in the rendered docs
+def download_natural_earth_features(app, env, docnames):  # noqa: ARG001
+    """Function to download coastlines and land boundaries prior to executing
+    documentation, so warnings don't appear in the rendered docs
     """
     for scale in ("110m", "50m"):
+        natural_earth(resolution=scale, category="physical", name="land")
         natural_earth(resolution=scale, category="physical", name="coastline")
 
 
 def setup(app):
     app.connect("env-before-read-docs", download_meshes)
-    app.connect("env-before-read-docs", download_coastlines)
+    app.connect("env-before-read-docs", download_natural_earth_features)
 
 
 # -- Project information -----------------------------------------------------

--- a/docs/developers_guide/design_docs/contouring.ipynb
+++ b/docs/developers_guide/design_docs/contouring.ipynb
@@ -35,8 +35,6 @@
     "import mosaic\n",
     "from mosaic.contour import ContourGraph, MPASContourGenerator\n",
     "\n",
-    "plt.rcParams[\"text.usetex\"] = True\n",
-    "\n",
     "SIZE = 3.5\n",
     "\n",
     "\n",


### PR DESCRIPTION
Also pre-downloads the land features, so that there's no warning printed in the docs. 