### PR TITLE
Do not set the collections transform

### DIFF
--- a/mosaic/polypcolor.py
+++ b/mosaic/polypcolor.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import numpy as np
-from cartopy.mpl.geoaxes import GeoAxes
 from matplotlib.axes import Axes
 from matplotlib.collections import PolyCollection
 from xarray.core.dataarray import DataArray
@@ -45,10 +44,6 @@ def _mirror_polycollection(ax, collection, descriptor, array, **kwargs):
     mirrored_collection.set_clim(vmin, vmax)
     # if vmin or vmax is None, use min/max from *orig* data to scale mirrored
     mirrored_collection.norm.autoscale_None(array)
-
-    # TODO: support wrapping for spherical meshes
-    if isinstance(ax, GeoAxes):
-        mirrored_collection.set_transform(descriptor.transform)
 
     # add the mirrored collection to the axes
     ax.add_collection(mirrored_collection)
@@ -98,10 +93,6 @@ def polypcolor(
     norm = kwargs.pop("norm", None)
 
     collection = PolyCollection(verts, array=array, norm=norm, **kwargs)
-
-    # only set the transform if GeoAxes
-    if isinstance(ax, GeoAxes):
-        collection.set_transform(descriptor.transform)
 
     collection._scale_norm(norm, vmin, vmax)
     ax.add_collection(collection)


### PR DESCRIPTION
Not setting the collection transform, for GeoAxes instances, results in ~50% (or more) speed up in rendering. I [reached out](https://discourse.matplotlib.org/t/setting-a-collections-transform-slows-down-rendering-by-a-factor-of-two/26160) to the cartopy dev's about whether this was really needed, but have not heard. If we were making an obvious mistake here, I think they would have said something. 

Native mesh contouring (#52) also produces [matplotlib collections ](https://docs.e3sm.org/mosaic/developers_guide/generated/mosaic.contour.MPASContourSet.html#mosaic.contour.MPASContourSet) on map projected figures. We do not set the transform there and have not had any issues. So, I'm feeling comfortable moving forward with this (for now at least). 

If we get a response or issues arise, we can always revert these changes. 

Closes #33. 